### PR TITLE
Add VS Code CLI shim with usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ AI is transforming every aspect of our lives—from the workplace to the classro
 ## 📂 How to Contribute
 We welcome contributions! Check out the `/src/content/posts/` directory to add new articles, or see `/public/README.md` for instructions on adding images and creating posts.
 
+### Working without the VS Code CLI
+This containerized environment cannot download or run Microsoft's official
+`code` binary, which previously caused a `command not found` error when trying
+to launch Visual Studio Code from the terminal. To surface more helpful
+guidance we now ship a small shim at `bin/code` that explains alternatives for
+opening the project in VS Code.
+
+To use it, add the repository's `bin` directory to your `PATH` in the current
+shell session:
+
+```bash
+export PATH="$(pwd)/bin:$PATH"
+```
+
+Running `code` (or `code --help`) afterwards will display a message detailing
+options such as using [vscode.dev](https://vscode.dev), connecting through VS
+Code Remote Tunnels, or cloning the repository locally where the real CLI is
+available.
+
 ---
 
 SurviveTheAI: Because the best way to predict the future is to create it. 🌍🤖

--- a/bin/code
+++ b/bin/code
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'EOT'
+Survive the AI workspace – VS Code CLI shim
+
+This container cannot download or run the official Visual Studio Code
+`code` binary, so this shim explains how to work with the project using
+supported alternatives.
+
+Usage: code [workspace]
+
+Options:
+  -h, --help   Show this help message.
+
+Behavior:
+  • If a workspace path is provided it is resolved to an absolute path.
+  • The script prints guidance on how to open that workspace in VS Code
+    using the browser-based client or VS Code's Remote Tunnels feature.
+EOT
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  show_help
+  exit 0
+fi
+
+workspace="${1:-.}"
+if ! workspace_path=$(realpath -m "$workspace" 2>/dev/null); then
+  printf '\nCannot resolve workspace path: %s\n' "$workspace" >&2
+  exit 1
+fi
+
+cat <<EOT
+The official VS Code 'code' CLI cannot be installed in this sandboxed
+container, but you can still work on:
+  $workspace_path
+
+Recommended options:
+
+1. VS Code for the Web
+   • Open https://vscode.dev in your browser.
+   • Use “Open Remote Repository” and point it at the repository you pushed
+     from this container (e.g. GitHub).
+
+2. VS Code Remote Tunnels
+   • On your local machine run 'code tunnel' to start a tunnel.
+   • Connect to the tunnel from VS Code Desktop and open the workspace path
+     shown above.
+
+3. Local checkout
+   • Clone the repository to your local machine where the 'code' CLI is
+     available, then run 'code $workspace'.
+
+Tip: add the repository's bin/ directory to your PATH to silence the
+original “command not found” error:
+
+  export PATH="$(pwd)/bin:$PATH"
+
+Run 'code --help' for this message again.
+EOT


### PR DESCRIPTION
## Summary
- add a `bin/code` shim so the VS Code command exists in the container
- document how to add the shim to PATH and how to use VS Code alternatives

## Testing
- code --help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea9375e60832699972e78e1411985)