### PR TITLE
Create professional article layout and content schema

### DIFF
--- a/.astro/collections/posts.schema.json
+++ b/.astro/collections/posts.schema.json
@@ -4,13 +4,13 @@
     "posts": {
       "type": "object",
       "properties": {
-        "filename": {
-          "type": "string"
-        },
         "title": {
           "type": "string"
         },
-        "pubDate": {
+        "description": {
+          "type": "string"
+        },
+        "date": {
           "anyOf": [
             {
               "type": "string",
@@ -29,37 +29,66 @@
         "author": {
           "type": "string"
         },
-        "description": {
-          "type": "string"
-        },
-        "excerpt": {
-          "type": "string"
-        },
-        "image": {
+        "category": {
           "type": "string"
         },
         "tags": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         },
-        "hero_image": {
+        "fear_index_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "heroImage": {
           "type": "string"
+        },
+        "heroImageAlt": {
+          "type": "string"
+        },
+        "affiliate_offer": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "label",
+            "url"
+          ],
+          "additionalProperties": false
+        },
+        "canonicalUrl": {
+          "type": "string",
+          "format": "uri"
         },
         "$schema": {
           "type": "string"
         }
       },
       "required": [
-        "filename",
         "title",
-        "pubDate",
-        "author",
         "description",
-        "excerpt",
-        "image",
-        "tags"
+        "date",
+        "author",
+        "category",
+        "tags",
+        "fear_index_score",
+        "heroImage",
+        "affiliate_offer",
+        "canonicalUrl"
       ],
       "additionalProperties": false
     }

--- a/public/images/article-template-hero.svg
+++ b/public/images/article-template-hero.svg
@@ -1,0 +1,13 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#0f0f0f"/>
+  <rect x="60" y="60" width="1080" height="510" rx="32" fill="url(#grad)" stroke="#2d2d2d" stroke-width="2"/>
+  <defs>
+    <linearGradient id="grad" x1="120" y1="120" x2="1080" y2="510" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1f1f1f"/>
+      <stop offset="1" stop-color="#0a0a0a"/>
+    </linearGradient>
+  </defs>
+  <text x="120" y="210" fill="#f5f5f5" font-family="'IBM Plex Sans', 'Inter', sans-serif" font-weight="700" font-size="72">Survive the AI</text>
+  <text x="120" y="300" fill="#a1a1a1" font-family="'IBM Plex Sans', 'Inter', sans-serif" font-size="36">Monochrome Article Hero Placeholder</text>
+  <text x="120" y="360" fill="#6b6b6b" font-family="'IBM Plex Sans', 'Inter', sans-serif" font-size="28">1200 × 630</text>
+</svg>

--- a/src/components/Byline.tsx
+++ b/src/components/Byline.tsx
@@ -1,0 +1,24 @@
+import type { FC } from 'react';
+
+type BylineProps = {
+  author: string;
+  displayDate: string;
+  isoDate: string;
+  readingTime: string;
+};
+
+const Byline: FC<BylineProps> = ({ author, displayDate, isoDate, readingTime }) => {
+  return (
+    <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-500">
+      <span className="font-medium text-neutral-300">{author}</span>
+      <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-700 sm:block" />
+      <time dateTime={isoDate} className="text-neutral-500">
+        {displayDate}
+      </time>
+      <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-700 sm:block" />
+      <span>{readingTime}</span>
+    </div>
+  );
+};
+
+export default Byline;

--- a/src/components/HeroImage.astro
+++ b/src/components/HeroImage.astro
@@ -1,0 +1,32 @@
+---
+const {
+  src,
+  alt,
+  caption,
+} = Astro.props as {
+  src: string;
+  alt: string;
+  caption?: string;
+};
+
+const srcset = `${src} 400w, ${src} 800w, ${src} 1200w`;
+---
+<figure class="space-y-3">
+  <div class="aspect-[1200/630] w-full overflow-hidden rounded-3xl bg-neutral-900">
+    <img
+      src={src}
+      alt={alt}
+      srcset={srcset}
+      sizes="(min-width: 1024px) 800px, 100vw"
+      loading="eager"
+      fetchpriority="high"
+      decoding="async"
+      width="1200"
+      height="630"
+      class="h-full w-full object-cover"
+    />
+  </div>
+  {caption && (
+    <figcaption class="text-sm text-neutral-500">{caption}</figcaption>
+  )}
+</figure>

--- a/src/components/PostGrid.astro
+++ b/src/components/PostGrid.astro
@@ -1,64 +1,47 @@
 ---
-
-import type { Post } from '../data/Posts'
+import type { Post } from '../data/Posts';
 import { categories } from '../data/categories';
 
 const { groupedItems } = Astro.props as { groupedItems: Post[][] };
 ---
-
 {groupedItems.map((posts) => {
   const [first, ...rest] = posts;
   return (
     <>
-      <div class="mb-2">
-        <a href={`/posts/${first.slug}`}>
-          <div class="bg-black rounded-[var(--radius)] shadow-[var(--shadow)] overflow-hidden flex flex-col">
-            <img src={`/images/${first.data.image}`} alt={first.data.image} class="w-full h-80 object-cover" />
-            <div class="p-5 flex-1 flex flex-col">
-              <div class="flex items-center gap-2 mb-2">
+      <div class="mb-6">
+        <a href={`/posts/${first.slug}/`} class="block">
+          <div class="flex flex-col overflow-hidden rounded-3xl border border-neutral-800 bg-neutral-900/60 shadow-glow transition hover:border-neutral-700">
+            <img src={first.data.heroImage} alt={first.data.heroImageAlt ?? first.data.title} class="h-80 w-full object-cover" loading="lazy" decoding="async" width="1200" height="630" />
+            <div class="flex flex-1 flex-col gap-4 p-6">
+              <div class="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-400">
                 {(() => {
-                  const catObj = categories.find(cat => cat.name === first.data.category);
-                  return catObj ? (
-                    <span
-                      class="px-2 py-0.5 rounded font-semibold text-xs"
-                      style={`background:${catObj.color}; color:#222;`}
-                      title={catObj.description}
-                    >
-                      {catObj.name}
-                    </span>
-                  ) : null;
+                  const catObj = categories.find((cat) => cat.name === first.data.category);
+                  return catObj ? <span>{catObj.name}</span> : <span>{first.data.category}</span>;
                 })()}
-                <h2 class="text-lg font-bold text-white font-sans">{first.data.title}</h2>
+                <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-700" />
+                <span>Fear Index {first.data.fear_index_score}</span>
               </div>
-              <p class="text-white font-sans flex-1">{first.data.excerpt}</p>
+              <h2 class="text-2xl font-semibold text-neutral-100 sm:text-3xl">{first.data.title}</h2>
+              <p class="text-neutral-400">{first.data.description}</p>
             </div>
           </div>
         </a>
       </div>
 
       {rest.length > 0 && (
-        <div class="grid gap-2 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 mb-2">
+        <div class="mb-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {rest.map((post) => (
-            <a href={`/posts/${post.slug}`}>
-              <div class="bg-black rounded-[var(--radius)] shadow-[var(--shadow)] overflow-hidden flex flex-col">
-                <img src={`/images/${post.data.image}`} alt={post.data.image} class="w-full h-40 object-cover" />
-                <div class="p-5 flex-1 flex flex-col">
-                  <div class="flex items-center gap-2 mb-2">
-                    {(() => {
-                      const catObj = categories.find(cat => cat.name === post.data.category);
-                      return catObj ? (
-                        <span
-                          class="px-2 py-0.5 rounded font-semibold text-xs"
-                          style={`background:${catObj.color}; color:#222;`}
-                          title={catObj.description}
-                        >
-                          {catObj.name}
-                        </span>
-                      ) : null;
-                    })()}
-                    <h2 class="text-lg font-bold text-white font-sans">{post.data.title}</h2>
+            <a key={post.slug} href={`/posts/${post.slug}/`} class="block">
+              <div class="flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-800 bg-neutral-900/50 transition hover:border-neutral-700">
+                <img src={post.data.heroImage} alt={post.data.heroImageAlt ?? post.data.title} class="h-40 w-full object-cover" loading="lazy" decoding="async" width="400" height="210" />
+                <div class="flex flex-1 flex-col gap-3 p-5">
+                  <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-500">
+                    <span>{post.data.category}</span>
+                    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-700" />
+                    <span>{post.data.fear_index_score}</span>
                   </div>
-                  <p class="text-white font-sans flex-1">{post.data.excerpt}</p>
+                  <h3 class="text-lg font-semibold text-neutral-100">{post.data.title}</h3>
+                  <p class="text-sm text-neutral-400">{post.data.description}</p>
                 </div>
               </div>
             </a>

--- a/src/components/RightRailRelated.astro
+++ b/src/components/RightRailRelated.astro
@@ -1,0 +1,51 @@
+---
+import type { PostEntry } from '../content/config';
+import { formatDate } from '../utils/format';
+
+const { category, currentSlug, posts } = Astro.props as {
+  category: string;
+  currentSlug: string;
+  posts: PostEntry[];
+};
+
+const sortedPosts = [...posts].filter((entry) => entry.slug !== currentSlug);
+sortedPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+const categoryMatches = sortedPosts.filter((entry) => entry.data.category === category);
+const related = (categoryMatches.length >= 3 ? categoryMatches : sortedPosts).slice(0, 5);
+---
+<section class="space-y-4">
+  <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">
+    More in {category}
+  </h2>
+  <ul class="space-y-4">
+    {related.map((entry) => {
+      const heroImage = entry.data.heroImage;
+      const dateLabel = formatDate(entry.data.date);
+
+      return (
+        <li>
+          <a href={`/posts/${entry.slug}/`} class="group flex items-center gap-4 rounded-2xl border border-transparent p-2 transition hover:border-neutral-700/80 hover:bg-neutral-900/40">
+            <div class="h-14 w-14 overflow-hidden rounded-xl bg-neutral-900">
+              <img
+                src={heroImage}
+                alt={entry.data.title}
+                loading="lazy"
+                decoding="async"
+                width="56"
+                height="56"
+                class="h-full w-full object-cover"
+              />
+            </div>
+            <div class="space-y-1">
+              <p class="text-sm font-medium text-neutral-200 transition group-hover:text-neutral-50">
+                {entry.data.title}
+              </p>
+              <p class="text-xs text-neutral-500">{dateLabel}</p>
+            </div>
+          </a>
+        </li>
+      );
+    })}
+  </ul>
+</section>

--- a/src/components/ShareBar.tsx
+++ b/src/components/ShareBar.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useMemo, useState, type FC } from 'react';
+
+type ShareBarProps = {
+  url: string;
+  title: string;
+  className?: string;
+  direction?: 'horizontal' | 'vertical';
+};
+
+const iconClasses = 'h-5 w-5';
+
+const ShareBar: FC<ShareBarProps> = ({ url, title, className = '', direction = 'horizontal' }) => {
+  const [copied, setCopied] = useState(false);
+
+  const shareLinks = useMemo(
+    () => ({
+      x: `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`,
+      linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
+    }),
+    [title, url],
+  );
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Unable to copy link', error);
+    }
+  }, [url]);
+
+  return (
+    <div className={`flex ${direction === 'vertical' ? 'flex-col gap-2' : 'flex-row gap-3'} ${className}`.trim()}>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="flex items-center gap-2 rounded-full border border-neutral-700/70 px-4 py-2 text-sm text-neutral-200 transition hover:border-neutral-500 hover:text-neutral-50"
+      >
+        <svg aria-hidden className={iconClasses} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M8 8h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-9a2 2 0 0 1 2-2z" />
+          <path d="M16 8V6a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v2" />
+        </svg>
+        <span>{copied ? 'Copied!' : 'Copy link'}</span>
+      </button>
+      <a
+        href={shareLinks.x}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="flex items-center gap-2 rounded-full border border-neutral-700/70 px-4 py-2 text-sm text-neutral-200 transition hover:border-neutral-500 hover:text-neutral-50"
+      >
+        <svg aria-hidden className={iconClasses} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M20 4.5c-.7.3-1.4.5-2.2.6a3.8 3.8 0 0 0 1.7-2.1 7.8 7.8 0 0 1-2.4.9A3.8 3.8 0 0 0 12 7.4c0 .3 0 .6.1.9A10.8 10.8 0 0 1 4.5 3.5a3.8 3.8 0 0 0 1.2 5.1 3.7 3.7 0 0 1-1.7-.5v.1a3.8 3.8 0 0 0 3 3.7 3.9 3.9 0 0 1-1.7.1 3.8 3.8 0 0 0 3.6 2.7A7.7 7.7 0 0 1 3 18c-.6 0-1.1 0-1.7-.1A10.9 10.9 0 0 0 7.6 20a10.8 10.8 0 0 0 11-11v-.5A7.7 7.7 0 0 0 20 4.5z" />
+        </svg>
+        <span>Share on X</span>
+      </a>
+      <a
+        href={shareLinks.linkedin}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="flex items-center gap-2 rounded-full border border-neutral-700/70 px-4 py-2 text-sm text-neutral-200 transition hover:border-neutral-500 hover:text-neutral-50"
+      >
+        <svg aria-hidden className={iconClasses} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M4.98 3.5a2 2 0 1 1 .02 4 2 2 0 0 1-.02-4zM3 8.75h3.95V21H3zM9.5 8.75H13v1.67h.05c.49-.92 1.69-1.9 3.48-1.9 3.72 0 4.4 2.25 4.4 5.18V21H16.9v-5.6c0-1.33-.03-3.04-1.86-3.04-1.86 0-2.15 1.45-2.15 2.95V21H9.5z" />
+        </svg>
+        <span>Share on LinkedIn</span>
+      </a>
+      <span className="sr-only" aria-live="polite">
+        {copied ? 'Link copied to clipboard' : ''}
+      </span>
+    </div>
+  );
+};
+
+export default ShareBar;

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,0 +1,65 @@
+import { useMemo, useState, type FC } from 'react';
+
+export type TableOfContentsHeading = {
+  depth: number;
+  slug: string;
+  text: string;
+};
+
+type TableOfContentsProps = {
+  headings: TableOfContentsHeading[];
+  title?: string;
+  className?: string;
+  initiallyCollapsed?: boolean;
+};
+
+const TableOfContents: FC<TableOfContentsProps> = ({
+  headings,
+  title = 'On this page',
+  className = '',
+  initiallyCollapsed = false,
+}) => {
+  const filtered = useMemo(() => headings.filter((heading) => heading.depth === 2 || heading.depth === 3), [headings]);
+  const [collapsed, setCollapsed] = useState(initiallyCollapsed);
+
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  const listClasses = collapsed
+    ? 'mt-4 hidden list-none space-y-2 pl-0 lg:block'
+    : 'mt-4 list-none space-y-2 pl-0';
+
+  return (
+    <nav className={`rounded-3xl border border-neutral-800/80 bg-neutral-950/60 p-5 text-sm text-neutral-400 ${className}`.trim()} aria-label="Table of contents">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-2 text-left font-medium text-neutral-200 lg:cursor-auto lg:text-neutral-300"
+        onClick={() => setCollapsed((value) => !value)}
+        aria-expanded={!collapsed}
+      >
+        <span>{title}</span>
+        <svg
+          className={`h-4 w-4 transition lg:hidden ${collapsed ? 'rotate-180' : ''}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path d="m6 15 6-6 6 6" />
+        </svg>
+      </button>
+      <ul className={listClasses}>
+        {filtered.map((heading) => (
+          <li key={heading.slug} className={heading.depth === 3 ? 'pl-4 text-neutral-500' : ''}>
+            <a href={`#${heading.slug}`} className="block rounded-md px-2 py-1 transition hover:text-neutral-100">
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default TableOfContents;

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,20 +1,31 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, z, type CollectionEntry } from 'astro:content';
 
-const posts = defineCollection({
-  schema: z.object({
-    filename: z.string(),
-    title: z.string(),
-    pubDate: z.date(),
-    author: z.string(),
-    description: z.string(),
-    excerpt: z.string(),
-    image: z.string(),
-    tags: z.array(z.string()),
-    hero_image: z.string().optional(),
+export const postSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  date: z.coerce.date(),
+  author: z.string(),
+  category: z.string(),
+  tags: z.array(z.string()).min(1),
+  fear_index_score: z.number().min(0).max(100),
+  heroImage: z.string(),
+  heroImageAlt: z.string().optional(),
+  affiliate_offer: z.object({
+    label: z.string(),
+    url: z.string().url(),
+    description: z.string().optional(),
   }),
-  layout: '../../layouts/PostLayout.astro',
+  canonicalUrl: z.string().url(),
 });
 
+const postsCollection = defineCollection({
+  type: 'content',
+  schema: postSchema,
+});
+
+export type PostFrontmatter = z.infer<typeof postSchema>;
+export type PostEntry = CollectionEntry<'posts'>;
+
 export const collections = {
-  posts,
+  posts: postsCollection,
 };

--- a/src/content/posts/ai-companionship.md
+++ b/src/content/posts/ai-companionship.md
@@ -1,13 +1,18 @@
 ---
-filename: "ai-companionship.md"
 title: "Placeholder: AI Companionship"
-pubDate: 2025-07-31
-author: "Admin"
 description: "This is a placeholder post for the AI Companionship category."
-excerpt: "Placeholder content for the AI Companionship category."
-image: "placeholder.jpg"
-tags: ["AI Companionship"]
+date: 2025-07-31
+author: "Admin"
 category: "AI Companionship"
+tags:
+  - "AI Companionship"
+fear_index_score: 42
+heroImage: "/images/placeholder-hero.svg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/ai-companionship"
 ---
 
 Content coming soon for this category.

--- a/src/content/posts/ai-job-displacement.md
+++ b/src/content/posts/ai-job-displacement.md
@@ -1,13 +1,18 @@
 ---
-filename: "ai-job-displacement.md"
 title: "Placeholder: AI Job Displacement"
-pubDate: 2025-07-31
-author: "Admin"
 description: "This is a placeholder post for the AI Job Displacement category."
-excerpt: "Placeholder content for the AI Job Displacement category."
-image: "placeholder.jpg"
-tags: ["AI Job Displacement"]
+date: 2025-07-31
+author: "Admin"
 category: "AI Job Displacement"
+tags:
+  - "AI Job Displacement"
+fear_index_score: 58
+heroImage: "/images/placeholder-hero.svg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/ai-job-displacement"
 ---
 
 Content coming soon for this category.

--- a/src/content/posts/ai-study-platforms-2025.md
+++ b/src/content/posts/ai-study-platforms-2025.md
@@ -1,15 +1,21 @@
 ---
-filename: "ai-study-platforms-2025.md"
 title: "Don’t Get Replaced: Pick the AI Study Platform That Builds the Right Skills"
-pubDate: 2025-11-07T12:00:00.000Z
-author: "Justin Cuevas"
 description: "Match your skill gaps to the right AI study tool—so you stay useful and employed."
-excerpt: "Pick study tools that train your brain, not your thumbs. Match skill gaps to platforms and run a 14-day test."
-image: "hero-banner-survive.png"
-tags: ["AI","learning","careers","education"]
+date: 2025-11-07T12:00:00Z
+author: "Justin Cuevas"
 category: "Learning"
-published: true
-layout: ../layouts/PostLayout.astro
+tags:
+  - "AI"
+  - "learning"
+  - "careers"
+  - "education"
+fear_index_score: 64
+heroImage: "/images/placeholder-hero.svg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/ai-study-platforms-2025"
 ---
 # Don’t Get Replaced: Pick the AI Study Platform That Builds the Right Skills
 

--- a/src/content/posts/aifears.md
+++ b/src/content/posts/aifears.md
@@ -1,14 +1,22 @@
 ---
-filename: "aifears.md"
 title: "Exploring the Biggest AI Fears in 2026"
-pubDate: 2025-07-29T17:52:00.000Z
-author: "Justin Cuevas"
 description: "What keeps experts, governments, and citizens up at night as AI accelerates into 2026?"
-excerpt: "From job loss to deepfakes to runaway intelligence — these are the AI fears shaping the next era."
-image: "fears.jpg"
-hero_image: "/images/fears.jpg"
-tags: ["AI", "ethics", "technology", "future", "society"]
+date: 2025-07-29T17:52:00Z
+author: "Justin Cuevas"
 category: "AI Job Displacement"
+tags:
+  - "AI"
+  - "ethics"
+  - "technology"
+  - "future"
+  - "society"
+fear_index_score: 88
+heroImage: "/images/fears.jpg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/aifears"
 ---
 
 As artificial intelligence races ahead in 2026, so do the anxieties surrounding it. From sci-fi scenarios to very real risks, people are asking: _Are we ready for what we’ve built?_ Below are the five biggest AI fears keeping both technologists and everyday people up at night.

--- a/src/content/posts/aiproofyourkid.md
+++ b/src/content/posts/aiproofyourkid.md
@@ -1,14 +1,22 @@
 ---
-filename: "aiproofyourkid.md"
 title: "How to AI-Proof Your Kid"
-pubDate: 2025-07-29T18:52:00.000Z
-author: "Justin Cuevas"
 description: "A practical guide for parents who want to prepare their children for a world dominated by artificial intelligence."
-excerpt: "If your child’s future job can be automated, you need to read this."
-image: "aiproofkid.jpg"
-hero_image: "/images/aiproofkid.jpg"
-tags: ["parenting", "AI", "future of work", "education", "technology"]
+date: 2025-07-29T18:52:00Z
+author: "Justin Cuevas"
 category: "AI Companionship"
+tags:
+  - "parenting"
+  - "AI"
+  - "future of work"
+  - "education"
+  - "technology"
+fear_index_score: 61
+heroImage: "/images/aiproofkid.jpg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/aiproofyourkid"
 ---
 
 As AI becomes more powerful and ubiquitous, parents are asking the big question: _How do I future-proof my kid?_ The short answer is: **you can’t fully** — but you can AI-proof them by developing human skills machines still can’t replicate.

--- a/src/content/posts/byebyedevs.md
+++ b/src/content/posts/byebyedevs.md
@@ -1,13 +1,21 @@
 ---
-filename: "byebyedevs.md"
-title: Are Programmers Becoming Obsolete in the Age of AI?
-description: As AI tools become more powerful, the traditional role of a programmer is evolving — and potentially disappearing.
-pubDate: 2025-07-26T13:52:00.000Z
-author: Alex Morgan
-tags: ["AI", "future of work", "software engineering", "automation"]
-image: ai-takes-over-code.jpg
-excerpt: Can AI really replace programmers? Or are we entering a new era where human creativity shifts from coding to guiding machines?
+title: "Are Programmers Becoming Obsolete in the Age of AI?"
+description: "As AI tools become more powerful, the traditional role of a programmer is evolving — and potentially disappearing."
+date: 2025-07-26T13:52:00Z
+author: "Alex Morgan"
 category: "AI Job Displacement"
+tags:
+  - "AI"
+  - "future of work"
+  - "software engineering"
+  - "automation"
+fear_index_score: 72
+heroImage: "/images/placeholder-hero.svg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/byebyedevs"
 ---
 
 > “AI won’t replace programmers — but programmers who use AI will replace those who don’t.”  

--- a/src/content/posts/cognitive-erosion.md
+++ b/src/content/posts/cognitive-erosion.md
@@ -1,13 +1,18 @@
 ---
-filename: "cognitive-erosion.md"
 title: "Placeholder: Cognitive Erosion"
-pubDate: 2025-07-31
-author: "Admin"
 description: "This is a placeholder post for the Cognitive Erosion category."
-excerpt: "Placeholder content for the Cognitive Erosion category."
-image: "placeholder.jpg"
-tags: ["Cognitive Erosion"]
+date: 2025-07-31
+author: "Admin"
 category: "Cognitive Erosion"
+tags:
+  - "Cognitive Erosion"
+fear_index_score: 49
+heroImage: "/images/placeholder-hero.svg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/cognitive-erosion"
 ---
 
 Content coming soon for this category.

--- a/src/content/posts/credentialism.md
+++ b/src/content/posts/credentialism.md
@@ -1,14 +1,22 @@
 ---
-filename: "credentialism.md"
 title: "Credentialism is Collapsing: Here's What Recruiters Actually Look For Now"
-pubDate: 2025-07-29T14:52:00.000Z
-author: "Justin Cuevas"
 description: "Degrees used to be the golden ticket. Not anymore. Discover what employers truly value in a post-credential era."
-excerpt: "Degrees are losing power. Recruiters now value what you can do over what you claim on paper."
-image: "recruiter.jpg"
-hero_image: "/images/recruiter.jpg"
-tags: ["hiring trends", "credentialism", "recruiting", "skills-first", "future of work"]
+date: 2025-07-29T14:52:00Z
+author: "Justin Cuevas"
 category: "AI Job Displacement"
+tags:
+  - "hiring trends"
+  - "credentialism"
+  - "recruiting"
+  - "skills-first"
+  - "future of work"
+fear_index_score: 54
+heroImage: "/images/recruiter.jpg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/credentialism"
 ---
 
 For decades, degrees were a gatekeeping mechanism in hiring. A bachelor's diploma from a reputable university could all but guarantee you an interview — and often, a job. But something has changed.

--- a/src/content/posts/gig-collapse.md
+++ b/src/content/posts/gig-collapse.md
@@ -1,13 +1,18 @@
 ---
-filename: "gig-collapse.md"
 title: "Placeholder: Gig Collapse"
-pubDate: 2025-07-31
-author: "Admin"
 description: "This is a placeholder post for the Gig Collapse category."
-excerpt: "Placeholder content for the Gig Collapse category."
-image: "placeholder.jpg"
-tags: ["Gig Collapse"]
+date: 2025-07-31
+author: "Admin"
 category: "Gig Collapse"
+tags:
+  - "Gig Collapse"
+fear_index_score: 53
+heroImage: "/images/placeholder-hero.svg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/gig-collapse"
 ---
 
 Content coming soon for this category.

--- a/src/content/posts/pro-template-demo.mdx
+++ b/src/content/posts/pro-template-demo.mdx
@@ -1,0 +1,83 @@
+---
+title: "The 2026 Survival Blueprint for AI Acceleration"
+description: "A field-tested system for staying relevant, resilient, and profitable while AI keeps speeding up."
+date: 2025-08-01T09:00:00Z
+author: "Justin Cuevas"
+category: "AI Strategy"
+tags:
+  - "future of work"
+  - "ai strategy"
+  - "resilience"
+  - "playbook"
+fear_index_score: 69
+heroImage: "/images/article-template-hero.svg"
+affiliate_offer:
+  label: "Download the Survival Blueprint"
+  url: "https://survivetheai.com/blueprint"
+  description: "A seven-page PDF to help you build an adaptive career roadmap."
+canonicalUrl: "https://survivetheai.com/posts/pro-template-demo"
+---
+
+The AI wave isn’t slowing down. If anything, **2026 will make 2025 look like onboarding**. The only sustainable response is to upgrade how you learn, build, and protect your leverage.
+
+## Phase 1 — Stabilize Your Inputs
+
+AI-driven volatility creates more noise than signal. The first move is to curate what gets your attention.
+
+### Audit Your Information Diet
+
+Document every feed, newsletter, and channel you consume for a week. Eliminate anything that:
+
+- Lacks actionable takeaways.
+- Makes you reactive or anxious.
+- Doesn’t align with your north star metric.
+
+### Establish Signal Windows
+
+Block two 45-minute windows each week for structured trend analysis. Use the time to:
+
+1. Log the most relevant AI shifts.
+2. Note potential threats or leverage points.
+3. Decide which ones deserve experiments.
+
+## Phase 2 — Build Leverage Sprints
+
+Once you control your inputs, design sprints that compound capability instead of burning you out.
+
+### Sprint Structure
+
+Each 14-day sprint should include:
+
+- **One automation upgrade** that saves at least 30 minutes per week.
+- **One skill expansion** with a measurable deliverable.
+- **One relationship touchpoint** that increases your surface area for opportunity.
+
+### Measurement Dashboard
+
+Track these metrics at the end of every sprint:
+
+- Time saved.
+- New revenue potential.
+- Confidence rating (1–5) on the skill you worked.
+
+## Phase 3 — Codify, Then Share
+
+Sprints without reflection waste momentum. Codify what you learn, then package it for visibility.
+
+### Post-Mortem Rhythm
+
+At the end of each sprint, answer:
+
+1. What worked?
+2. What broke?
+3. What gets doubled down on next?
+
+### Publish the Proof
+
+Turn your notes into a 400-word update or short Loom video. This becomes your living portfolio and **makes future recruiters trust your adaptability**.
+
+## Final Word
+
+The people who win the AI decade won’t be the most technical. They’ll be the most **deliberate**. Stabilize your attention, build sprints around leverage, and ship the receipts.
+
+Stay dangerous.

--- a/src/content/posts/rapidchange.md
+++ b/src/content/posts/rapidchange.md
@@ -1,14 +1,22 @@
 ---
-filename: "rapidchange.md"
 title: "How to Adapt to Rapid Change in the Age of AI"
-pubDate: 2025-07-29T16:52:00.000Z
-author: "Justin Cuevas"
 description: "From careers to creativity, learn how to thrive in a world where everything changes faster than ever."
-excerpt: "AI isn’t just changing the world — it’s speeding it up. Here's how to stay relevant and resilient."
-image: "lifechange.jpg"
-hero_image: "/images/lifechange.jpg"
-tags: ["adaptability", "AI", "technology", "resilience", "future of work"]
+date: 2025-07-29T16:52:00Z
+author: "Justin Cuevas"
 category: "Cognitive Erosion"
+tags:
+  - "adaptability"
+  - "AI"
+  - "technology"
+  - "resilience"
+  - "future of work"
+fear_index_score: 47
+heroImage: "/images/lifechange.jpg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/rapidchange"
 ---
 
 In an era where AI evolves weekly and industries shift overnight, adaptability isn’t optional — it’s survival.

--- a/src/content/posts/riseofgigeconomy.md
+++ b/src/content/posts/riseofgigeconomy.md
@@ -1,14 +1,21 @@
 ---
-filename: "riseofgigeconomy.md"
 title: "The Rise of the Gig Economy"
-pubDate: 2025-07-29T15:52:00.000Z
-author: "Justin Cuevas"
 description: "How freelancing, contract work, and on-demand labor are reshaping the modern workforce."
-excerpt: "Delivery drivers, freelancers, and side hustlers — here's what's coming."
-image: "uber.jpg"
-hero_image: "/images/uber.jpg"
-tags: ["gig economy", "future of work", "freelancing", "technology"]
+date: 2025-07-29T15:52:00Z
+author: "Justin Cuevas"
 category: "Gig Collapse"
+tags:
+  - "gig economy"
+  - "future of work"
+  - "freelancing"
+  - "technology"
+fear_index_score: 51
+heroImage: "/images/uber.jpg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/riseofgigeconomy"
 ---
 
 ## Introduction

--- a/src/content/posts/soft-extinction.md
+++ b/src/content/posts/soft-extinction.md
@@ -1,13 +1,18 @@
 ---
-filename: "soft-extinction.md"
 title: "Placeholder: Soft Extinction"
-pubDate: 2025-07-31
-author: "Admin"
 description: "This is a placeholder post for the Soft Extinction category."
-excerpt: "Placeholder content for the Soft Extinction category."
-image: "placeholder.jpg"
-tags: ["Soft Extinction"]
+date: 2025-07-31
+author: "Admin"
 category: "Soft Extinction"
+tags:
+  - "Soft Extinction"
+fear_index_score: 57
+heroImage: "/images/placeholder-hero.svg"
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/posts/soft-extinction"
 ---
 
 Content coming soon for this category.

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,44 +1,132 @@
 ---
+import HeroImage from '../components/HeroImage.astro';
+import Byline from '../components/Byline.tsx';
+import RightRailRelated from '../components/RightRailRelated.astro';
+import ShareBar from '../components/ShareBar.tsx';
+import TableOfContents from '../components/TableOfContents.tsx';
+import '../styles/tokens.css';
 import '../styles/tailwind.css';
+import type { PostEntry } from '../content/config';
+import type { MarkdownHeading } from 'astro';
+import { formatDate, formatReadingMinutes } from '../utils/format';
 
-const { frontmatter, Content } = Astro.props;
-const { title, description, hero_image } = frontmatter;
+const {
+  post,
+  headings,
+  readingTime,
+  shareUrl,
+  allPosts,
+} = Astro.props as {
+  post: PostEntry;
+  headings: MarkdownHeading[];
+  readingTime: number;
+  shareUrl: string;
+  allPosts: PostEntry[];
+};
+
+const { title, description, date, author, heroImage, heroImageAlt, category, fear_index_score, canonicalUrl } = post.data;
+const displayDate = formatDate(date);
+const readingTimeLabel = formatReadingMinutes(readingTime);
+const isoDate = date.toISOString();
+const heroAlt = heroImageAlt ?? `${title} hero image`;
+const filteredHeadings = headings.filter((heading) => heading.depth === 2 || heading.depth === 3);
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: title,
+  description,
+  image: heroImage.startsWith('http') ? heroImage : new URL(heroImage, canonicalUrl).toString(),
+  datePublished: isoDate,
+  dateModified: isoDate,
+  author: {
+    '@type': 'Person',
+    name: author,
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Survive the AI',
+  },
+  mainEntityOfPage: canonicalUrl,
+};
 ---
 <!DOCTYPE html>
-<html lang="en" class="bg-base-bg text-base-text">
+<html lang="en" class="bg-neutral-950 text-neutral-100">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     {description && <meta name="description" content={description} />}
-    <link rel="stylesheet" href="/src/styles/tailwind.css" />
-    <title>{title}</title>
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content={title} />
+    {description && <meta property="og:description" content={description} />}
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:image" content={heroImage.startsWith('http') ? heroImage : new URL(heroImage, canonicalUrl).toString()} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    {description && <meta name="twitter:description" content={description} />}
+    <meta name="twitter:image" content={heroImage.startsWith('http') ? heroImage : new URL(heroImage, canonicalUrl).toString()} />
+    <title>{title} · Survive the AI</title>
+    <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
   </head>
-  <body class="min-h-screen">
-    <header class="px-6 md:px-0 py-10">
-      <div class="mx-auto max-w-5xl">
-        <h1 class="text-4xl font-bold tracking-tight">{title}</h1>
-        {description && <p class="mt-2 text-base text-base-mute">{description}</p>}
-      </div>
-    </header>
-
-    {hero_image && (
-      <figure class="w-full bg-black not-prose">
-        <img
-          src={hero_image}
-          alt={title}
-          class="w-full h-[300px] md:h-[420px] lg:h-[520px] object-cover"
-          loading="eager"
-          decoding="async"
-        />
-      </figure>
-    )}
-
-    <main class="px-6 md:px-0">
-      <div class="mx-auto max-w-5xl">
-        <article class="prose lg:prose-lg mx-auto">
-          <Content />
-        </article>
-      </div>
-    </main>
+  <body class="bg-neutral-950 text-neutral-100 antialiased">
+    <div class="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+      <article class="lg:grid lg:grid-cols-12 lg:gap-12">
+        <div class="lg:col-span-8 space-y-6 sm:space-y-8 pb-16">
+          <slot name="hero">
+            <HeroImage src={heroImage} alt={heroAlt} />
+          </slot>
+          <header class="space-y-4">
+            <div class="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-500">
+              <span>{category}</span>
+              <span aria-hidden class="hidden h-1 w-1 rounded-full bg-neutral-700 sm:block" />
+              <span>Fear Index: {fear_index_score}</span>
+            </div>
+            <slot name="heading">
+              <h1 class="text-3xl font-extrabold tracking-tight sm:text-4xl">{title}</h1>
+              {description && <p class="text-base text-neutral-400 sm:text-lg">{description}</p>}
+            </slot>
+            <div class="lg:hidden">
+              <slot name="share-bar-top">
+                <ShareBar client:load url={shareUrl} title={title} className="mt-2" />
+              </slot>
+            </div>
+          </header>
+          <Byline
+            client:idle
+            author={author}
+            displayDate={displayDate}
+            isoDate={isoDate}
+            readingTime={readingTimeLabel}
+          />
+          <slot name="inline-cta" />
+          {filteredHeadings.length > 0 && (
+            <div class="lg:hidden">
+              <TableOfContents client:load headings={filteredHeadings} initiallyCollapsed={true} />
+            </div>
+          )}
+          <div class="prose prose-invert mx-auto max-w-none text-base sm:text-lg">
+            <slot />
+          </div>
+          <footer class="pt-6">
+            <slot name="share-bar-bottom">
+              <ShareBar client:load url={shareUrl} title={title} />
+            </slot>
+          </footer>
+        </div>
+        <aside class="lg:col-span-4 lg:space-y-8 space-y-8">
+          <div class="lg:sticky lg:top-24 lg:space-y-8 space-y-8">
+            <RightRailRelated category={category} currentSlug={post.slug} posts={allPosts} />
+            {filteredHeadings.length > 0 && (
+              <div class="hidden lg:block">
+                <TableOfContents client:load headings={filteredHeadings} initiallyCollapsed={false} />
+              </div>
+            )}
+          </div>
+        </aside>
+      </article>
+    </div>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,27 +17,22 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
 const chunkSize = 5;
 
 const posts: Post[] = await getCollection('posts');
-posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
+posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 const groupedItems = chunkArray(posts, chunkSize);
-
-console.log(posts);
-console.log(groupedItems);
 ---
 
 <Layout>
-  	<main class="bg-white py-20">
-		<div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
-			<div class="bg-white">
-				<div>
-					<PostGrid groupedItems={groupedItems}/>
-				</div>
-
-				<!-- Sidebar
-				<aside class="space-y-6">
-				<FearIndexPreview />
-				<NewsletterSignup />
-				</aside> -->
-			</div>
-		</div>
-	</main>
+  <main class="bg-neutral-950 py-20">
+    <div class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
+      <div class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div>
+          <PostGrid groupedItems={groupedItems} />
+        </div>
+        <aside class="space-y-6">
+          <FearIndexPreview />
+          <NewsletterSignup />
+        </aside>
+      </div>
+    </div>
+  </main>
 </Layout>

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,16 +1,56 @@
 ---
 import { getCollection } from 'astro:content';
+import PostLayout from '../../layouts/PostLayout.astro';
+import { readingTime } from '../../utils/readingTime';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
   return posts.map((post) => ({
     params: { slug: post.slug },
-    props: { post },
+    props: { post, allPosts: posts },
   }));
 }
 
-const { post } = Astro.props;
-const { Content } = await post.render();
+const { post, allPosts } = Astro.props;
+const { Content, headings } = await post.render();
+const { minutes } = readingTime(post.body ?? '');
+const shareUrl = post.data.canonicalUrl || new URL(`/posts/${post.slug}/`, Astro.site ?? 'https://survivetheai.com').toString();
+const affiliate = post.data.affiliate_offer;
 ---
-
-<Content />
+<PostLayout
+  post={post}
+  headings={headings}
+  readingTime={minutes}
+  shareUrl={shareUrl}
+  allPosts={allPosts}
+>
+  {affiliate && (
+    <div
+      slot="inline-cta"
+      class="space-y-4 rounded-3xl border border-neutral-800/80 bg-neutral-950/70 p-6 shadow-[0_10px_30px_-20px_rgba(0,0,0,0.8)]"
+    >
+      <div class="space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Featured offer</p>
+        <h2 class="text-xl font-semibold text-neutral-100 sm:text-2xl">{affiliate.label}</h2>
+        {affiliate.description && <p class="text-sm text-neutral-400 sm:text-base">{affiliate.description}</p>}
+      </div>
+      <div class="flex flex-col gap-3 sm:flex-row">
+        <a
+          href={affiliate.url}
+          class="inline-flex items-center justify-center rounded-full bg-neutral-50 px-5 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-200"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Access the offer
+        </a>
+        <a
+          href={shareUrl}
+          class="inline-flex items-center justify-center rounded-full border border-neutral-700/80 px-5 py-2 text-sm font-semibold text-neutral-200 transition hover:border-neutral-500 hover:text-neutral-50"
+        >
+          Share this playbook
+        </a>
+      </div>
+    </div>
+  )}
+  <Content />
+</PostLayout>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -2,42 +2,64 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Dark prose for Markdown */
-.prose{
-  @apply max-w-prose prose-invert mx-auto;
-  @apply prose-headings:font-semibold prose-headings:tracking-tight;
-  @apply prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl;
-  @apply prose-p:leading-7 prose-a:text-inherit prose-a:underline-offset-4 hover:prose-a:underline;
-  @apply prose-hr:my-10;
-  @apply prose-blockquote:border-l-4 prose-blockquote:border-zinc-600;
-  @apply prose-img:rounded-xl prose-img:mx-auto;
-  @apply prose-code:bg-zinc-900 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded;
-  @apply prose-pre:bg-zinc-900 prose-pre:rounded-xl prose-pre:p-4;
+@layer base {
+  html {
+    font-family: var(--font-sans);
+    background-color: var(--color-page);
+    color: var(--color-text);
+    scroll-behavior: smooth;
+  }
+
+  body {
+    background-color: inherit;
+    color: inherit;
+    min-height: 100vh;
+  }
+
+  ::selection {
+    background-color: rgba(244, 244, 245, 0.15);
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+    text-decoration-color: transparent;
+    transition: color 0.2s ease, text-decoration-color 0.2s ease;
+  }
+
+  a:hover,
+  a:focus-visible {
+    text-decoration: underline;
+    text-decoration-color: currentColor;
+  }
 }
 
-/* GFM tables */
-.prose table{ @apply w-full block overflow-x-auto border-collapse my-6; }
-.prose thead th{ @apply border-b border-zinc-700 text-left py-2 px-3; }
-.prose tbody td{ @apply border-b border-zinc-800 py-2 px-3 align-top; }
-.prose tbody tr:nth-child(odd) td{ @apply bg-zinc-900/30; }
+.prose {
+  @apply mx-auto max-w-none text-neutral-200 leading-7 sm:leading-8;
+  @apply prose-invert prose-headings:tracking-tight prose-headings:font-semibold;
+  @apply prose-h1:text-3xl prose-h1:sm:text-4xl prose-h1:font-extrabold;
+  @apply prose-h2:text-2xl prose-h2:sm:text-3xl prose-h2:font-bold;
+  @apply prose-h3:text-xl prose-h3:sm:text-2xl prose-h3:font-semibold;
+  @apply prose-p:text-base prose-p:sm:text-lg;
+  @apply prose-a:no-underline hover:prose-a:underline;
+  @apply prose-img:rounded-2xl prose-img:border prose-img:border-neutral-800;
+  @apply prose-code:bg-neutral-900 prose-code:px-2 prose-code:py-1 prose-code:rounded-md prose-code:text-neutral-100;
+  @apply prose-pre:bg-neutral-900 prose-pre:border prose-pre:border-neutral-800 prose-pre:rounded-2xl prose-pre:p-5;
+  @apply prose-hr:border-neutral-800 prose-blockquote:border-l-4 prose-blockquote:border-neutral-700 prose-blockquote:text-neutral-400;
+}
 
-/* Callout utility */
-.callout{ @apply border-l-4 border-zinc-600 pl-4 py-3 my-6 bg-zinc-900/40 rounded-r; }
+.prose table {
+  @apply w-full overflow-x-auto rounded-2xl border border-neutral-800 text-sm;
+}
 
-/* Figure + image sizing utilities */
-.figure-wide{ @apply not-prose my-8; }
-.figure-narrow{ @apply my-8; }
-.figcap{ @apply mt-3 text-sm text-base-mute text-center; }
+.prose thead th {
+  @apply border-b border-neutral-800 px-4 py-3 text-left text-neutral-300;
+}
 
-.img-wide{ @apply w-full max-w-5xl mx-auto rounded-xl shadow; }
-.img-medium{ @apply w-full max-w-3xl mx-auto rounded-xl shadow; }
-.img-small{ @apply w-full max-w-xl mx-auto rounded-lg shadow; }
-.img-tuck{ @apply md:float-right md:ml-6 md:mb-2 md:w-[360px] rounded-lg; }
+.prose tbody td {
+  @apply border-b border-neutral-900/60 px-4 py-3 align-top text-neutral-400;
+}
 
-/* Ensure images inside prose respect container widths */
-.prose img{ @apply max-w-full h-auto; }
-
-/* If a figure should break out of the prose container, use `.figure-wide` + `not-prose` on the element */
-.figure-wide.not-prose{ @apply -mx-6 md:mx-0; }
-
-
+.prose tbody tr:nth-child(odd) td {
+  @apply bg-neutral-900/40;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,27 @@
+:root {
+  color-scheme: dark;
+  --color-page: #09090b;
+  --color-surface: #111113;
+  --color-border: #1f1f23;
+  --color-text: #f5f5f5;
+  --color-muted: #9ca3af;
+  --color-subtle: #6b7280;
+  --max-page-width: 1200px;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+  --space-xl: 3rem;
+  --font-sans: 'IBM Plex Sans', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace;
+}
+
+@media (min-width: 640px) {
+  :root {
+    --space-xs: 0.75rem;
+    --space-sm: 1rem;
+    --space-md: 1.75rem;
+    --space-lg: 2.5rem;
+    --space-xl: 3.5rem;
+  }
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,14 @@
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+export function formatDate(date: Date): string {
+  return dateFormatter.format(date);
+}
+
+export function formatReadingMinutes(minutes: number): string {
+  const rounded = Math.max(1, Math.round(minutes));
+  return `${rounded} min read`;
+}

--- a/src/utils/readingTime.ts
+++ b/src/utils/readingTime.ts
@@ -1,0 +1,16 @@
+const WORDS_PER_MINUTE = 220;
+
+export type ReadingTimeResult = {
+  minutes: number;
+  words: number;
+};
+
+export function readingTime(content: string, wordsPerMinute = WORDS_PER_MINUTE): ReadingTimeResult {
+  const words = content.trim().split(/\s+/).filter(Boolean).length;
+  const minutes = words === 0 ? 0 : words / Math.max(wordsPerMinute, 1);
+
+  return {
+    minutes,
+    words,
+  };
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -5,15 +5,61 @@ export default {
     './public/**/*.html',
   ],
   theme: {
+    container: {
+      center: true,
+      padding: {
+        DEFAULT: '1rem',
+        sm: '1.5rem',
+        lg: '2rem',
+      },
+      screens: {
+        '2xl': '1200px',
+      },
+    },
     extend: {
       colors: {
-        base: {
-          bg: '#0a0a0a',
-          text: '#e5e5e5',
-          mute: '#a1a1aa',
+        neutral: {
+          50: '#f4f4f5',
+          100: '#e4e4e7',
+          200: '#d4d4d8',
+          300: '#a1a1aa',
+          400: '#71717a',
+          500: '#52525b',
+          600: '#3f3f46',
+          700: '#27272a',
+          800: '#18181b',
+          900: '#0f0f11',
+          950: '#09090b',
         },
       },
+      fontFamily: {
+        sans: ['"IBM Plex Sans"', 'Inter', 'system-ui', 'sans-serif'],
+        mono: ['"IBM Plex Mono"', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+      },
+      fontSize: {
+        'display-1': ['clamp(2.5rem, 3vw + 1rem, 3rem)', { lineHeight: '1.1', letterSpacing: '-0.03em' }],
+        'display-2': ['clamp(2rem, 2vw + 1rem, 2.5rem)', { lineHeight: '1.15', letterSpacing: '-0.015em' }],
+        'body-lg': ['1.125rem', { lineHeight: '1.8' }],
+      },
       maxWidth: { prose: '72ch' },
+      boxShadow: {
+        glow: '0 24px 72px -40px rgba(0,0,0,0.75)',
+      },
+      typography: ({ theme }) => ({
+        invert: {
+          css: {
+            '--tw-prose-body': theme('colors.neutral.200'),
+            '--tw-prose-headings': theme('colors.neutral.50'),
+            '--tw-prose-links': theme('colors.neutral.50'),
+            '--tw-prose-bold': theme('colors.neutral.50'),
+            '--tw-prose-quotes': theme('colors.neutral.300'),
+            '--tw-prose-quote-borders': theme('colors.neutral.700'),
+            '--tw-prose-code': theme('colors.neutral.100'),
+            '--tw-prose-pre-bg': theme('colors.neutral.900'),
+            '--tw-prose-hr': theme('colors.neutral.800'),
+          },
+        },
+      }),
     },
   },
   plugins: [require('@tailwindcss/typography')],


### PR DESCRIPTION
## Summary
- enforce a richer `posts` content collection schema and update markdown frontmatter to include hero imagery, affiliate offer metadata, and canonical URLs
- build a new article layout with responsive hero image, byline, share bar, table of contents, and right-rail related posts plus supporting React islands
- add utility helpers, design tokens, Tailwind updates, and a sample long-form post to exercise the new template

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ebbd959588326946ddb04e1a8c345)