### PR TITLE
Normalize post imagery sizing

### DIFF
--- a/src/components/HeroImage.astro
+++ b/src/components/HeroImage.astro
@@ -1,32 +1,75 @@
 ---
-const {
-  src,
-  alt,
-  caption,
-} = Astro.props as {
-  src: string;
-  alt: string;
-  caption?: string;
+import { getImage } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+
+const { src, alt = '' } = Astro.props as {
+  src: ImageMetadata | string;
+  alt?: string;
 };
 
-const srcset = `${src} 400w, ${src} 800w, ${src} 1200w`;
+const sizes = '(min-width: 1024px) 760px, 100vw';
+
+let resolvedSrc: string = typeof src === 'string' ? src : src.src;
+let useGeneratedImage = typeof src !== 'string';
+let isSvg = false;
+
+if (typeof src !== 'string') {
+  isSvg = src.format === 'svg';
+  if (isSvg) {
+    resolvedSrc = src.src;
+    useGeneratedImage = false;
+  }
+} else {
+  const trimmed = src.trim();
+  resolvedSrc = trimmed;
+  isSvg = trimmed.toLowerCase().endsWith('.svg');
+  useGeneratedImage = false;
+}
+
+const generatedImage = useGeneratedImage
+  ? await getImage({
+      src: src as ImageMetadata,
+      widths: [400, 760, 1200],
+      formats: ['jpg'],
+      quality: 78,
+    })
+  : undefined;
+
+const fallbackSrcset = [400, 760, 1200]
+  .map((width) => `${resolvedSrc} ${width}w`)
+  .join(', ');
 ---
-<figure class="space-y-3">
-  <div class="aspect-[1200/630] w-full overflow-hidden rounded-3xl bg-neutral-900">
-    <img
-      src={src}
-      alt={alt}
-      srcset={srcset}
-      sizes="(min-width: 1024px) 800px, 100vw"
-      loading="eager"
-      fetchpriority="high"
-      decoding="async"
-      width="1200"
-      height="630"
-      class="h-full w-full object-cover"
-    />
+<div class="mx-auto mb-6 w-full max-w-[760px]">
+  <div class="relative aspect-[1200/630] overflow-hidden rounded-xl bg-neutral-900/50">
+    {generatedImage ? (
+      <picture class="absolute inset-0 block h-full w-full">
+        {Object.values(generatedImage.sources).map((source) => (
+          <source type={source.type} srcset={source.srcset} sizes={sizes} />
+        ))}
+        <img
+          src={generatedImage.src}
+          alt={alt}
+          loading="eager"
+          fetchpriority="high"
+          decoding="async"
+          width={generatedImage.width}
+          height={generatedImage.height}
+          class="absolute inset-0 h-full w-full object-cover"
+        />
+      </picture>
+    ) : (
+      <img
+        src={resolvedSrc}
+        alt={alt}
+        srcset={fallbackSrcset}
+        sizes={sizes}
+        loading="eager"
+        fetchpriority="high"
+        decoding="async"
+        width="1200"
+        height="630"
+        class="absolute inset-0 h-full w-full object-cover"
+      />
+    )}
   </div>
-  {caption && (
-    <figcaption class="text-sm text-neutral-500">{caption}</figcaption>
-  )}
-</figure>
+</div>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -73,8 +73,8 @@ const structuredData = {
   </head>
   <body class="bg-neutral-950 text-neutral-100 antialiased">
     <div class="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
-      <article class="lg:grid lg:grid-cols-12 lg:gap-12">
-        <div class="lg:col-span-8 space-y-6 sm:space-y-8 pb-16">
+      <div class="lg:grid lg:grid-cols-12 lg:gap-10">
+        <main class="pb-16 space-y-6 sm:space-y-8 lg:col-span-8">
           <slot name="hero">
             <HeroImage src={heroImage} alt={heroAlt} />
           </slot>
@@ -107,17 +107,17 @@ const structuredData = {
               <TableOfContents client:load headings={filteredHeadings} initiallyCollapsed={true} />
             </div>
           )}
-          <div class="prose prose-invert mx-auto max-w-none text-base sm:text-lg">
+          <article class="mx-auto w-full max-w-[760px] prose prose-invert prose-headings:font-extrabold prose-a:underline-offset-2">
             <slot />
-          </div>
+          </article>
           <footer class="pt-6">
             <slot name="share-bar-bottom">
               <ShareBar client:load url={shareUrl} title={title} />
             </slot>
           </footer>
-        </div>
-        <aside class="lg:col-span-4 lg:space-y-8 space-y-8">
-          <div class="lg:sticky lg:top-24 lg:space-y-8 space-y-8">
+        </main>
+        <aside class="space-y-8 lg:col-span-4">
+          <div class="space-y-8 lg:sticky lg:top-24">
             <RightRailRelated category={category} currentSlug={post.slug} posts={allPosts} />
             {filteredHeadings.length > 0 && (
               <div class="hidden lg:block">
@@ -126,7 +126,7 @@ const structuredData = {
             )}
           </div>
         </aside>
-      </article>
+      </div>
     </div>
   </body>
 </html>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -25,3 +25,26 @@
     --space-xl: 3.5rem;
   }
 }
+
+.prose figure {
+  margin: 1.25rem auto;
+  max-width: 760px;
+}
+
+.prose img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 0.75rem;
+  max-width: 760px;
+  width: 100%;
+  height: auto;
+}
+
+.prose figcaption {
+  color: rgb(115 115 115);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-align: center;
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- enforce a centered content column with a 760px max width and grid-aligned right rail in the post layout
- refactor the hero image component to constrain aspect ratio and generate responsive sources when metadata is available
- add default prose styles so markdown images stay centered, responsive, and use consistent captions

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec00329dc8326930d3b4596ff11e6)