### PR TITLE
Remove Fear Index references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to SurviveTheAI – your essential guide to thriving in the age of artif
 SurviveTheAI is a modern, content-driven web application designed to empower individuals, families, and professionals to navigate the rapidly changing world shaped by AI. Our mission is to demystify artificial intelligence, address real fears, and provide actionable insights so you can future-proof your life and career.
 
 ## 🌟 Key Features
-- **Fear Index:** Explore the most common concerns about AI and discover practical ways to overcome them.
+- **Topic Explorer:** Browse the most common concerns about AI and discover practical ways to overcome them.
 - **Expert Insights:** Read blog posts and guides from thought leaders, educators, and technologists.
 - **Interactive Quizzes:** Test your knowledge and learn how to adapt to the AI revolution.
 - **Newsletter:** Stay ahead with curated news, tips, and resources delivered straight to your inbox.

--- a/public/README.md
+++ b/public/README.md
@@ -1,31 +1,25 @@
 
-# Admin Note: Fear Index vs. Categories — What’s the Difference?
+# Admin Note: Topic Tags and Categories
 
-Great question — and it's important we get this distinction clear.
+Great question — and it's important we keep our language consistent.
 
-### ✅ **Fear Index vs. Categories — What’s the Difference?**
+### ✅ **Topics vs. Categories — How They Work Together**
 
-In this project, **they refer to the same core topics**, but:
+In this project, **topics and categories refer to the same set of key themes**, but we use them in slightly different contexts:
 
 ---
 
-#### 1. **Fear Index** = Strategic Framing
+#### 1. **Topics** = Editorial Lens
 
-* Think of it as our **editorial lens**.
-* It's how we frame the major disruptive forces AI is triggering.
-* The Fear Index is used in:
-  * Landing page messaging
-  * Quizzes and scoring systems
-  * Brand voice and positioning
-  * Reports or interactive tools
-
-> Example: “Our Fear Index shows a spike in Cognitive Dependency this quarter…”
+* Think of topics as our **storytelling angle**.
+* They shape landing page messaging, quizzes, and overall brand voice.
+* When designing new experiences, align them to a topic so content feels cohesive.
 
 ---
 
 #### 2. **Categories** = Content Taxonomy
 
-* These are **technical tags or labels** we assign to content.
+* Categories are **technical tags or labels** assigned to content.
 * Used in:
   * Markdown frontmatter
   * Filters and search tools
@@ -35,21 +29,14 @@ In this project, **they refer to the same core topics**, but:
 > Example: A blog post about AI tutors would be labeled:
 
 ```yaml
-category: "Parenting & Education Collapse"
+category: "Parenting & Education"
 ```
 
 ---
 
 ### ✅ TL;DR:
 
-They represent the same **10 topics**, but:
-
-* **Fear Index** is **brand messaging and strategic framing**
-* **Categories** are **developer-usable tags** for organizing content
-
-You can confidently say:
-
-> “Our site categories are based directly on the Survive the AI Fear Index.”
+They represent the same topics, but **topics** guide narrative framing while **categories** keep content organized for developers and tooling.
 
 # /public
 Static assets (images, fonts, etc.) go here.

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,11 +1,11 @@
 ---
-import { FEAR_CATEGORIES } from '../data/categories';
-const { title, excerpt, imageUrl, fearCategories, date, category } = Astro.props;
+import { TOPIC_CATEGORIES } from '../data/categories';
+const { title, excerpt, imageUrl, topics, date, category } = Astro.props;
 
 // Find the category object for this post
 const catObj =
-  (Array.isArray(fearCategories) && FEAR_CATEGORIES.find((cat) => cat.key === fearCategories[0])) ||
-  FEAR_CATEGORIES.find((cat) => cat.label === category);
+  (Array.isArray(topics) && TOPIC_CATEGORIES.find((cat) => cat.key === topics[0])) ||
+  TOPIC_CATEGORIES.find((cat) => cat.label === category);
 ---
 
 <article class="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition duration-200 border border-gray-200 dark:border-gray-700">
@@ -19,7 +19,7 @@ const catObj =
         title={catObj?.description}
       >
         {/* Optionally render icon here if you have an icon component */}
-        {catObj ? catObj.name : category}
+        {catObj ? catObj.label : category}
       </span>
       <span>{date}</span>
     </div>

--- a/src/components/PostGrid.astro
+++ b/src/components/PostGrid.astro
@@ -1,10 +1,10 @@
 ---
 import type { Post } from '../data/Posts';
-import { FEAR_CATEGORIES } from '../data/categories';
+import { TOPIC_CATEGORIES } from '../data/categories';
 
 const { groupedItems } = Astro.props as { groupedItems: Post[][] };
 
-const categoryByKey = new Map(FEAR_CATEGORIES.map((c) => [c.key, c]));
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
 const primaryLabel = (keys?: string[]) => {
   if (!keys || keys.length === 0) return undefined;
   const first = categoryByKey.get(keys[0]);
@@ -21,9 +21,9 @@ const primaryLabel = (keys?: string[]) => {
             <img src={first.data.heroImage} alt={first.data.heroImageAlt ?? first.data.title} class="h-80 w-full object-cover" loading="lazy" decoding="async" width="1200" height="630" />
             <div class="flex flex-1 flex-col gap-4 p-6">
               <div class="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-500">
-                <span>{primaryLabel(first.data.fearCategories) ?? first.data.category}</span>
+                <span>{primaryLabel(first.data.topics) ?? first.data.category}</span>
                 <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
-                <span>Fear Index {first.data.fear_index_score}</span>
+                <span>Impact Score {first.data.impact_score}</span>
               </div>
               <h2 class="text-2xl font-semibold text-neutral-900 sm:text-3xl">{first.data.title}</h2>
               <p class="text-neutral-700">{first.data.description}</p>
@@ -40,9 +40,9 @@ const primaryLabel = (keys?: string[]) => {
                 <img src={post.data.heroImageThumb ?? post.data.heroImage} alt={post.data.heroImageAlt ?? post.data.title} class="h-40 w-full object-cover" loading="lazy" decoding="async" width="400" height="210" />
                 <div class="flex flex-1 flex-col gap-3 p-5">
                   <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
-                    <span>{primaryLabel(post.data.fearCategories) ?? post.data.category}</span>
+                    <span>{primaryLabel(post.data.topics) ?? post.data.category}</span>
                     <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
-                    <span>{post.data.fear_index_score}</span>
+                    <span>{post.data.impact_score}</span>
                   </div>
                   <h3 class="text-lg font-semibold text-neutral-900">{post.data.title}</h3>
                   <p class="text-sm text-neutral-700">{post.data.description}</p>

--- a/src/components/RightRailRelated.astro
+++ b/src/components/RightRailRelated.astro
@@ -1,15 +1,15 @@
 ---
 import type { PostEntry } from '../content/config';
 import { formatDate } from '../utils/format';
-import { FEAR_CATEGORIES } from '../data/categories';
+import { TOPIC_CATEGORIES } from '../data/categories';
 
 const { currentSlug, posts } = Astro.props as {
   currentSlug: string;
   posts: PostEntry[];
 };
 
-const categoryByKey = new Map(FEAR_CATEGORIES.map((c) => [c.key, c]));
-const getPrimaryKey = (entry: PostEntry) => entry.data.fearCategories?.[0];
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const getPrimaryKey = (entry: PostEntry) => entry.data.topics?.[0];
 const getPrimaryLabel = (entry: PostEntry) => {
   const key = getPrimaryKey(entry);
   return key ? categoryByKey.get(key)?.label : undefined;
@@ -18,10 +18,10 @@ const getPrimaryLabel = (entry: PostEntry) => {
 const sortedPosts = [...posts].filter((entry) => entry.slug !== currentSlug);
 sortedPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
-const currentPrimaryKey = posts.find((p) => p.slug === currentSlug)?.data.fearCategories?.[0];
+const currentPrimaryKey = posts.find((p) => p.slug === currentSlug)?.data.topics?.[0];
 const relatedPool =
   currentPrimaryKey != null
-    ? sortedPosts.filter((entry) => entry.data.fearCategories?.includes(currentPrimaryKey))
+    ? sortedPosts.filter((entry) => entry.data.topics?.includes(currentPrimaryKey))
     : sortedPosts;
 const related = (relatedPool.length >= 3 ? relatedPool : sortedPosts).slice(0, 5);
 ---

--- a/src/components/TopicPreview.astro
+++ b/src/components/TopicPreview.astro
@@ -1,11 +1,11 @@
 ---
-// FearIndexPreview component: sidebar list of fear categories
-import { FEAR_CATEGORIES } from '../data/categories';
+// TopicPreview component: sidebar list of key themes
+import { TOPIC_CATEGORIES } from '../data/categories';
 
-const categories = [...FEAR_CATEGORIES].sort((a, b) => a.order - b.order);
+const categories = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
 ---
 <div class="bg-card-bg rounded-[var(--radius)] shadow-[var(--shadow)] p-4">
-  <h3 class="font-bold mb-2 text-[var(--primary)] font-sans">Fear Index</h3>
+  <h3 class="font-bold mb-2 text-[var(--primary)] font-sans">Key Topics</h3>
   <ul class="space-y-1">
     {categories.map(cat => (
       <li class="text-text-muted font-sans flex items-center gap-2">

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,7 +6,7 @@ export const postSchema = z.object({
   date: z.coerce.date(),
   author: z.string(),
   category: z.string().optional(),
-  fearCategories: z.array(
+  topics: z.array(
     z.enum([
       'work-money',
       'kids-school',
@@ -16,7 +16,7 @@ export const postSchema = z.object({
     ]),
   ),
   tags: z.array(z.string()).min(1),
-  fear_index_score: z.number().min(0).max(100),
+  impact_score: z.number().min(0).max(100),
   heroImage: z.string(),
   heroImageAlt: z.string().optional(),
   affiliate_offer: z.object({

--- a/src/content/posts/Entry-Level Is Dead.md
+++ b/src/content/posts/Entry-Level Is Dead.md
@@ -4,12 +4,12 @@ description: "AI is deleting entry-level roles and hollowing out the career ladd
 date: 2024-12-04
 author: "Admin"
 category: "Work & Money – AI Job Displacement"
-fearCategories:
+topics:
   - "work-money"
 tags:
   - "Entry-Level"
   - "Automation"
-fear_index_score: 67
+impact_score: 67
 heroImage: "/images/entry-level-dead-ladder-bw.jpg"
 heroImageAlt: "Black-and-white career ladder with the bottom rungs missing, fading into shadow"
 affiliate_offer:

--- a/src/content/posts/Replacing Human Intimacy.md
+++ b/src/content/posts/Replacing Human Intimacy.md
@@ -4,13 +4,13 @@ description: "AI companions promise endless empathy and attention -- this post e
 date: 2025-12-05
 author: "Admin"
 category: "Love, Sex & Connection - AI Relationships & Synthetic Intimacy"
-fearCategories:
+topics:
   - "love-connection"
 tags:
   - "AI companions"
   - "loneliness"
   - "synthetic intimacy"
-fear_index_score: 63
+impact_score: 63
 heroImage: "/images/The_Artificial_Companion.jpg"
 heroImageAlt: "AI companion reaching out to a human in a dimly lit digital space"
 affiliate_offer:

--- a/src/content/posts/ai-companionship.md
+++ b/src/content/posts/ai-companionship.md
@@ -4,11 +4,11 @@ description: "This is a placeholder post for the AI Companionship category."
 date: 2025-07-31
 author: "Admin"
 category: "Love, Sex & Connection – AI Relationships & Synthetic Intimacy"
-fearCategories:
+topics:
   - "love-connection"
 tags:
   - "AI Companionship"
-fear_index_score: 42
+impact_score: 42
 heroImage: "/images/placeholder-hero.svg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/ai-job-displacement.md
+++ b/src/content/posts/ai-job-displacement.md
@@ -4,11 +4,11 @@ description: "This is a placeholder post for the AI Job Displacement category."
 date: 2025-07-31
 author: "Admin"
 category: "Work & Money – AI Job Displacement"
-fearCategories:
+topics:
   - "work-money"
 tags:
   - "AI Job Displacement"
-fear_index_score: 58
+impact_score: 58
 heroImage: "/images/placeholder-hero.svg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/ai-study-platforms-2025.md
+++ b/src/content/posts/ai-study-platforms-2025.md
@@ -4,14 +4,14 @@ description: "Match your skill gaps to the right AI study tool—so you stay use
 date: 2025-11-07T12:00:00Z
 author: "Lee Cuevas"
 category: "Kids & School – AI vs Your Children’s Future"
-fearCategories:
+topics:
   - "kids-school"
 tags:
   - "AI"
   - "learning"
   - "careers"
   - "education"
-fear_index_score: 64
+impact_score: 64
 heroImage: "/images/ai-study-platforms-2025.jpg"
 heroImageAlt: "AI study platforms — skill-building comparison"
 heroImageThumb: "/images/ai-study-platforms-2025.jpg"

--- a/src/content/posts/aifears.md
+++ b/src/content/posts/aifears.md
@@ -4,7 +4,7 @@ description: "What keeps experts, governments, and citizens up at night as AI ac
 date: 2025-07-29T17:52:00Z
 author: "Justin Cuevas"
 category: "System Shock – Soft Extinction & Collapse"
-fearCategories:
+topics:
   - "system-shock"
 tags:
   - "AI"
@@ -12,7 +12,7 @@ tags:
   - "technology"
   - "future"
   - "society"
-fear_index_score: 88
+impact_score: 88
 heroImage: "/images/fears.jpg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/aiproofyourkid.md
+++ b/src/content/posts/aiproofyourkid.md
@@ -4,7 +4,7 @@ description: "A practical guide for parents who want to prepare their children f
 date: 2025-07-29T18:52:00Z
 author: "Justin Cuevas"
 category: "Kids & School – AI vs Your Children’s Future"
-fearCategories:
+topics:
   - "kids-school"
 tags:
   - "parenting"
@@ -12,7 +12,7 @@ tags:
   - "future of work"
   - "education"
   - "technology"
-fear_index_score: 61
+impact_score: 61
 heroImage: "/images/aiproofkid.jpg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/alone-together.md
+++ b/src/content/posts/alone-together.md
@@ -4,13 +4,13 @@ description: "AI friends soothe loneliness in the short term but can erode real-
 date: 2025-12-05
 author: "Admin"
 category: "Love, Sex & Connection - AI Relationships & Synthetic Intimacy"
-fearCategories:
+topics:
   - "love-connection"
 tags:
   - "AI companions"
   - "loneliness"
   - "emotional dependence"
-fear_index_score: 64
+impact_score: 64
 heroImage: "/images/alone-together.png"
 heroImageAlt: "A solitary face with digital tears made of binary code"
 affiliate_offer:

--- a/src/content/posts/byebyedevs.md
+++ b/src/content/posts/byebyedevs.md
@@ -4,14 +4,14 @@ description: "As AI tools become more powerful, the traditional role of a progra
 date: 2025-07-26T13:52:00Z
 author: "Alex Morgan"
 category: "Work & Money – AI Job Displacement"
-fearCategories:
+topics:
   - "work-money"
 tags:
   - "AI"
   - "future of work"
   - "software engineering"
   - "automation"
-fear_index_score: 72
+impact_score: 72
 heroImage: "/images/placeholder-hero.svg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/cognitive-erosion.md
+++ b/src/content/posts/cognitive-erosion.md
@@ -4,11 +4,11 @@ description: "This is a placeholder post for the Cognitive Erosion category."
 date: 2025-07-31
 author: "Admin"
 category: "Mind & Attention – Cognitive Erosion & Offloading"
-fearCategories:
+topics:
   - "mind-attention"
 tags:
   - "Cognitive Erosion"
-fear_index_score: 49
+impact_score: 49
 heroImage: "/images/placeholder-hero.svg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/credentialism.md
+++ b/src/content/posts/credentialism.md
@@ -4,7 +4,7 @@ description: "Degrees used to be the golden ticket. Not anymore. Discover what e
 date: 2025-07-29T14:52:00Z
 author: "Justin Cuevas"
 category: "Work & Money – AI Job Displacement"
-fearCategories:
+topics:
   - "work-money"
 tags:
   - "hiring trends"
@@ -12,7 +12,7 @@ tags:
   - "recruiting"
   - "skills-first"
   - "future of work"
-fear_index_score: 54
+impact_score: 54
 heroImage: "/images/recruiter.jpg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/gig-collapse.md
+++ b/src/content/posts/gig-collapse.md
@@ -4,11 +4,11 @@ description: "This is a placeholder post for the Gig Collapse category."
 date: 2025-07-31
 author: "Admin"
 category: "Work & Money – AI Job Displacement"
-fearCategories:
+topics:
   - "work-money"
 tags:
   - "Gig Collapse"
-fear_index_score: 53
+impact_score: 53
 heroImage: "/images/placeholder-hero.svg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/pro-template-demo.mdx
+++ b/src/content/posts/pro-template-demo.mdx
@@ -4,14 +4,14 @@ description: "A field-tested system for staying relevant, resilient, and profita
 date: 2025-08-01T09:00:00Z
 author: "Justin Cuevas"
 category: "Work & Money – AI Job Displacement"
-fearCategories:
+topics:
   - "work-money"
 tags:
   - "future of work"
   - "ai strategy"
   - "resilience"
   - "playbook"
-fear_index_score: 69
+impact_score: 69
 heroImage: "/images/article-template-hero.svg"
 affiliate_offer:
   label: "Download the Survival Blueprint"

--- a/src/content/posts/rapidchange.md
+++ b/src/content/posts/rapidchange.md
@@ -4,7 +4,7 @@ description: "From careers to creativity, learn how to thrive in a world where e
 date: 2025-07-29T16:52:00Z
 author: "Justin Cuevas"
 category: "Mind & Attention – Cognitive Erosion & Offloading"
-fearCategories:
+topics:
   - "mind-attention"
 tags:
   - "adaptability"
@@ -12,7 +12,7 @@ tags:
   - "technology"
   - "resilience"
   - "future of work"
-fear_index_score: 47
+impact_score: 47
 heroImage: "/images/lifechange.jpg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/riseofgigeconomy.md
+++ b/src/content/posts/riseofgigeconomy.md
@@ -4,14 +4,14 @@ description: "How freelancing, contract work, and on-demand labor are reshaping 
 date: 2025-07-29T15:52:00Z
 author: "Justin Cuevas"
 category: "Work & Money – AI Job Displacement"
-fearCategories:
+topics:
   - "work-money"
 tags:
   - "gig economy"
   - "future of work"
   - "freelancing"
   - "technology"
-fear_index_score: 51
+impact_score: 51
 heroImage: "/images/uber.jpg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/content/posts/soft-extinction.md
+++ b/src/content/posts/soft-extinction.md
@@ -4,11 +4,11 @@ description: "This is a placeholder post for the Soft Extinction category."
 date: 2025-07-31
 author: "Admin"
 category: "System Shock – Soft Extinction & Collapse"
-fearCategories:
+topics:
   - "system-shock"
 tags:
   - "Soft Extinction"
-fear_index_score: 57
+impact_score: 57
 heroImage: "/images/placeholder-hero.svg"
 affiliate_offer:
   label: "Get the Survival Playbook"

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -1,2 +1,2 @@
 # /src/data
-Static JSON or JS files (Fear Index categories, quiz logic).
+Static JSON or JS files (topic categories, quiz logic).

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -1,5 +1,5 @@
 // src/data/categories.ts
-// Single source of truth for all Fear Index categories
+// Single source of truth for all topic categories
 
 export interface Category {
   key: string;
@@ -11,7 +11,7 @@ export interface Category {
   description?: string;
 }
 
-export const FEAR_CATEGORIES: Category[] = [
+export const TOPIC_CATEGORIES: Category[] = [
   {
     key: "work-money",
     label: "Work & Money – AI Job Displacement",

--- a/src/data/fear-index.json
+++ b/src/data/fear-index.json
@@ -1,5 +1,0 @@
-// Fear Index categories stub
-[
-  { "category": "AI Takeover", "score": 0 },
-  { "category": "Job Loss", "score": 0 }
-]

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -9,7 +9,7 @@ import '../styles/tailwind.css';
 import type { PostEntry } from '../content/config';
 import type { MarkdownHeading } from 'astro';
 import { formatDate, formatReadingMinutes } from '../utils/format';
-import { FEAR_CATEGORIES } from '../data/categories';
+import { TOPIC_CATEGORIES } from '../data/categories';
 
 const {
   post,
@@ -25,14 +25,14 @@ const {
   allPosts: PostEntry[];
 };
 
-const { title, description, date, author, heroImage, heroImageAlt, fearCategories, fear_index_score, canonicalUrl } = post.data;
+const { title, description, date, author, heroImage, heroImageAlt, topics, impact_score, canonicalUrl } = post.data;
 const displayDate = formatDate(date);
 const readingTimeLabel = formatReadingMinutes(readingTime);
 const isoDate = date.toISOString();
 const heroAlt = heroImageAlt ?? `${title} hero image`;
 const filteredHeadings = headings.filter((heading) => heading.depth === 2 || heading.depth === 3);
-const categoryByKey = new Map(FEAR_CATEGORIES.map((c) => [c.key, c]));
-const primaryCategory = fearCategories?.[0] ? categoryByKey.get(fearCategories[0]) : undefined;
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const primaryCategory = topics?.[0] ? categoryByKey.get(topics[0]) : undefined;
 const categoryLabel = primaryCategory?.label;
 
 const structuredData = {
@@ -97,9 +97,9 @@ const structuredData = {
           </slot>
           <header class="space-y-4">
             <div class="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-500">
-              <span>{categoryLabel ?? 'Fear Index'}</span>
+              <span>{categoryLabel ?? 'Key Topic'}</span>
               <span aria-hidden class="hidden h-1 w-1 rounded-full bg-neutral-300 sm:block" />
-              <span>Fear Index: {fear_index_score}</span>
+              <span>Impact Score: {impact_score}</span>
             </div>
             <slot name="heading">
               <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl">{title}</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../layouts/BaseLayout.astro';
 import PostGrid from '../components/PostGrid.astro';
-import FearIndexPreview from '../components/FearIndexPreview.astro';
+import TopicPreview from '../components/TopicPreview.astro';
 import NewsletterSignup from '../components/NewsletterSignup.astro';
 import { getCollection } from 'astro:content';
 import type { Post } from '../data/Posts';
@@ -29,7 +29,7 @@ const groupedItems = chunkArray(posts, chunkSize);
           <PostGrid groupedItems={groupedItems} />
         </div>
         <aside class="space-y-6">
-          <FearIndexPreview />
+          <TopicPreview />
           <NewsletterSignup />
         </aside>
       </div>


### PR DESCRIPTION
## Summary
- replace Fear Index terminology with neutral topic and impact score language across the site
- rename supporting components and data structures to use topic-based naming
- update all content frontmatter to the new schema and remove unused assets

## Testing
- npm run build *(fails: npm not available in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933734e46cc83269f59f2b570f7b234)