### PR TITLE
Add v2 versioned layout and posts

### DIFF
--- a/.astro/collections/posts.schema.json
+++ b/.astro/collections/posts.schema.json
@@ -63,6 +63,18 @@
         "heroImageAlt": {
           "type": "string"
         },
+        "featured": {
+          "type": "boolean"
+        },
+        "evergreen": {
+          "type": "boolean"
+        },
+        "start_here": {
+          "type": "boolean"
+        },
+        "version": {
+          "type": "number"
+        },
         "affiliate_offer": {
           "type": "object",
           "properties": {
@@ -100,6 +112,7 @@
         "tags",
         "impact_score",
         "heroImage",
+        "version",
         "affiliate_offer",
         "canonicalUrl"
       ],

--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -204,6 +204,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("./../src/content/config.js");
+	export type ContentConfig = typeof import("../src/content/config.js");
 	export type LiveContentConfig = never;
 }

--- a/src/components/v2/RightRailRelated.astro
+++ b/src/components/v2/RightRailRelated.astro
@@ -1,0 +1,64 @@
+---
+import type { PostEntry } from '../../content/config';
+import { formatDate } from '../../utils/format';
+import { TOPIC_CATEGORIES } from '../../data/categories';
+
+const { currentSlug, posts } = Astro.props as {
+  currentSlug: string;
+  posts: PostEntry[];
+};
+
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const getPrimaryKey = (entry: PostEntry) => entry.data.topics?.[0];
+const getPrimaryLabel = (entry: PostEntry) => {
+  const key = getPrimaryKey(entry);
+  return key ? categoryByKey.get(key)?.label : undefined;
+};
+
+const sortedPosts = [...posts].filter((entry) => entry.slug !== currentSlug);
+sortedPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+const currentPrimaryKey = posts.find((p) => p.slug === currentSlug)?.data.topics?.[0];
+const relatedPool =
+  currentPrimaryKey != null
+    ? sortedPosts.filter((entry) => entry.data.topics?.includes(currentPrimaryKey))
+    : sortedPosts;
+const related = (relatedPool.length >= 3 ? relatedPool : sortedPosts).slice(0, 5);
+---
+<section class="space-y-4">
+  <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-600">
+    More in {currentPrimaryKey ? categoryByKey.get(currentPrimaryKey)?.label ?? 'Related' : 'Related'}
+  </h2>
+  <ul class="space-y-4">
+    {related.map((entry) => {
+      const heroImage = entry.data.heroImage;
+      const dateLabel = formatDate(entry.data.date);
+      const label = getPrimaryLabel(entry) ?? 'Related';
+
+      return (
+        <li>
+          <a href={`/v2/posts/${entry.slug}/`} class="group flex items-center gap-4 rounded-2xl border border-neutral-200 p-2 transition hover:border-neutral-300 hover:bg-neutral-50">
+            <div class="h-14 w-14 overflow-hidden rounded-xl bg-neutral-100">
+              <img
+                src={heroImage}
+                alt={entry.data.title}
+                loading="lazy"
+                decoding="async"
+                width="56"
+                height="56"
+                class="h-full w-full object-cover"
+              />
+            </div>
+            <div class="space-y-1">
+              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">{label}</p>
+              <p class="text-sm font-medium text-neutral-900 transition group-hover:text-neutral-700">
+                {entry.data.title}
+              </p>
+              <p class="text-xs text-neutral-600">{dateLabel}</p>
+            </div>
+          </a>
+        </li>
+      );
+    })}
+  </ul>
+</section>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -19,6 +19,10 @@ export const postSchema = z.object({
   impact_score: z.number().min(0).max(100),
   heroImage: z.string(),
   heroImageAlt: z.string().optional(),
+  featured: z.boolean().optional(),
+  evergreen: z.boolean().optional(),
+  start_here: z.boolean().optional(),
+  version: z.number(),
   affiliate_offer: z.object({
     label: z.string(),
     url: z.string().url(),

--- a/src/content/posts/AI Is Leaving the Cloud.md
+++ b/src/content/posts/AI Is Leaving the Cloud.md
@@ -13,6 +13,7 @@ tags:
 impact_score: 71
 heroImage: "/images/ai-leaving-the-cloud-job-loss.png"
 heroImageAlt: "AI escaping centralized cloud infrastructure into individual laptops, symbolizing loss of control and accelerated job displacement"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/Entry-Level Is Dead.md
+++ b/src/content/posts/Entry-Level Is Dead.md
@@ -12,6 +12,7 @@ tags:
 impact_score: 67
 heroImage: "/images/entry-level-dead-ladder-bw.jpg"
 heroImageAlt: "Black-and-white career ladder with the bottom rungs missing, fading into shadow"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/Replacing Human Intimacy.md
+++ b/src/content/posts/Replacing Human Intimacy.md
@@ -13,6 +13,7 @@ tags:
 impact_score: 63
 heroImage: "/images/The_Artificial_Companion.jpg"
 heroImageAlt: "AI companion reaching out to a human in a dimly lit digital space"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/ai-companionship.md
+++ b/src/content/posts/ai-companionship.md
@@ -10,6 +10,7 @@ tags:
   - "AI Companionship"
 impact_score: 42
 heroImage: "/images/placeholder-hero.svg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/ai-job-displacement.md
+++ b/src/content/posts/ai-job-displacement.md
@@ -10,6 +10,7 @@ tags:
   - "AI Job Displacement"
 impact_score: 58
 heroImage: "/images/placeholder-hero.svg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/ai-study-platforms-2025.md
+++ b/src/content/posts/ai-study-platforms-2025.md
@@ -15,6 +15,7 @@ impact_score: 64
 heroImage: "/images/ai-study-platforms-2025.jpg"
 heroImageAlt: "AI study platforms — skill-building comparison"
 heroImageThumb: "/images/ai-study-platforms-2025.jpg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/aifears.md
+++ b/src/content/posts/aifears.md
@@ -14,6 +14,7 @@ tags:
   - "society"
 impact_score: 88
 heroImage: "/images/fears.jpg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/aiproofyourkid.md
+++ b/src/content/posts/aiproofyourkid.md
@@ -14,6 +14,7 @@ tags:
   - "technology"
 impact_score: 61
 heroImage: "/images/aiproofkid.jpg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/alone-together.md
+++ b/src/content/posts/alone-together.md
@@ -13,6 +13,7 @@ tags:
 impact_score: 64
 heroImage: "/images/alone-together.png"
 heroImageAlt: "A solitary face with digital tears made of binary code"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/byebyedevs.md
+++ b/src/content/posts/byebyedevs.md
@@ -13,6 +13,7 @@ tags:
   - "automation"
 impact_score: 72
 heroImage: "/images/placeholder-hero.svg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/cognitive-erosion.md
+++ b/src/content/posts/cognitive-erosion.md
@@ -10,6 +10,7 @@ tags:
   - "Cognitive Erosion"
 impact_score: 49
 heroImage: "/images/placeholder-hero.svg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/credentialism.md
+++ b/src/content/posts/credentialism.md
@@ -14,6 +14,7 @@ tags:
   - "future of work"
 impact_score: 54
 heroImage: "/images/recruiter.jpg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/gig-collapse.md
+++ b/src/content/posts/gig-collapse.md
@@ -10,6 +10,7 @@ tags:
   - "Gig Collapse"
 impact_score: 53
 heroImage: "/images/placeholder-hero.svg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/pro-template-demo.mdx
+++ b/src/content/posts/pro-template-demo.mdx
@@ -13,6 +13,7 @@ tags:
   - "playbook"
 impact_score: 69
 heroImage: "/images/article-template-hero.svg"
+version: 1
 affiliate_offer:
   label: "Download the Survival Blueprint"
   url: "https://survivetheai.com/blueprint"

--- a/src/content/posts/rapidchange.md
+++ b/src/content/posts/rapidchange.md
@@ -14,6 +14,7 @@ tags:
   - "future of work"
 impact_score: 47
 heroImage: "/images/lifechange.jpg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/riseofgigeconomy.md
+++ b/src/content/posts/riseofgigeconomy.md
@@ -13,6 +13,7 @@ tags:
   - "technology"
 impact_score: 51
 heroImage: "/images/uber.jpg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/soft-extinction.md
+++ b/src/content/posts/soft-extinction.md
@@ -10,6 +10,7 @@ tags:
   - "Soft Extinction"
 impact_score: 57
 heroImage: "/images/placeholder-hero.svg"
+version: 1
 affiliate_offer:
   label: "Get the Survival Playbook"
   url: "https://survivetheai.com/playbook"

--- a/src/content/posts/v2-evergreen-mental-fitness.md
+++ b/src/content/posts/v2-evergreen-mental-fitness.md
@@ -1,0 +1,32 @@
+﻿---
+title: "Evergreen Mental Fitness Stack"
+description: "Daily practices to keep your attention, mood, and focus sharp when AI noise is relentless."
+date: 2025-07-15
+author: "SurviveTheAI Editorial"
+category: "Mind & Attention – Cognitive Erosion & Offloading"
+topics:
+  - "mind-attention"
+tags:
+  - "mental health"
+  - "attention"
+  - "habits"
+impact_score: 71
+heroImage: "/images/cognitive-survival-stack.png"
+heroImageAlt: "Illustration of a cognitive survival stack diagram"
+evergreen: true
+version: 2
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/v2/posts/v2-evergreen-mental-fitness"
+---
+
+Mental fitness is a skill — and the noise of AI hype makes it harder. This evergreen routine keeps you steady:
+
+- **Morning reset (10 min):** breathwork + quick journaling to reset focus.
+- **Information diet:** cap doomscrolling; batch check feeds once per day.
+- **Single-tasking blocks:** 45–60 minute deep work intervals with analog notes.
+- **Detox:** one no-screen hour before bed to downshift.
+
+Bookmark this protocol. It survives algorithm changes, new apps, and shifting headlines.

--- a/src/content/posts/v2-featured-survival-playbook.md
+++ b/src/content/posts/v2-featured-survival-playbook.md
@@ -1,0 +1,35 @@
+﻿---
+title: "AI Survival Playbook 2025"
+description: "A concise plan to stay employable, resilient, and calm as AI acceleration reshapes every role."
+date: 2025-08-01
+author: "SurviveTheAI Editorial"
+category: "Work & Money – Resilience at Speed"
+topics:
+  - "work-money"
+tags:
+  - "career"
+  - "playbook"
+  - "resilience"
+  - "ai disruption"
+impact_score: 78
+heroImage: "/images/job-security-reality-check.png"
+heroImageAlt: "Professional looking at job security metrics on a dashboard"
+featured: true
+version: 2
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/v2/posts/v2-featured-survival-playbook"
+---
+
+The AI wave is accelerating — and so is the turbulence it creates for teams, careers, and mental health.
+
+This V2 featured guide distills the tactics we’ve seen work across tech, operations, and creative teams:
+
+1. Ship in smaller increments with clearer experiments.
+2. Pair AI copilots with human reviewers for critical work.
+3. Move your portfolio to a cadence you can sustain weekly.
+4. Build redundancy into income streams to handle shocks.
+
+Use this as your anchor: a crisp checklist you can revisit when everything else feels noisy.

--- a/src/content/posts/v2-start-here-orientation.md
+++ b/src/content/posts/v2-start-here-orientation.md
@@ -1,0 +1,32 @@
+﻿---
+title: "Start Here: SurviveTheAI V2 Orientation"
+description: "Your guided on-ramp to the new SurviveTheAI experience — what’s changed and where to go first."
+date: 2025-07-20
+author: "SurviveTheAI Editorial"
+category: "System Shock – Navigating Change"
+topics:
+  - "system-shock"
+tags:
+  - "orientation"
+  - "guide"
+  - "survivetheai"
+impact_score: 64
+heroImage: "/images/info_ai_adoption.png"
+heroImageAlt: "Information graphic about AI adoption momentum"
+start_here: true
+version: 2
+affiliate_offer:
+  label: "Get the Survival Playbook"
+  url: "https://survivetheai.com/playbook"
+  description: "Download the free resilience playbook to stay employable through 2026."
+canonicalUrl: "https://survivetheai.com/v2/posts/v2-start-here-orientation"
+---
+
+Welcome to SurviveTheAI V2. This orientation packs everything you need to get value fast:
+
+1) A map of the new versioned layout and why posts are split by version.  
+2) The core playbooks to read first.  
+3) Where to track updates, drops, and experiments.  
+4) How to share feedback so we can iterate faster.
+
+Follow this first, then jump into the featured and evergreen posts — you’ll have context for everything else.

--- a/src/layouts/v2/PostLayout.astro
+++ b/src/layouts/v2/PostLayout.astro
@@ -1,0 +1,149 @@
+---
+import HeroImage from '../../components/HeroImage.astro';
+import Byline from '../../components/Byline.tsx';
+import RightRailRelated from '../../components/v2/RightRailRelated.astro';
+import ShareBar from '../../components/ShareBar.tsx';
+import TableOfContents from '../../components/TableOfContents.tsx';
+import '../../styles/tokens.css';
+import '../../styles/tailwind.css';
+import type { PostEntry } from '../../content/config';
+import type { MarkdownHeading } from 'astro';
+import { formatDate, formatReadingMinutes } from '../../utils/format';
+import { TOPIC_CATEGORIES } from '../../data/categories';
+
+const {
+  post,
+  headings,
+  readingTime,
+  shareUrl,
+  allPosts,
+} = Astro.props as {
+  post: PostEntry;
+  headings: MarkdownHeading[];
+  readingTime: number;
+  shareUrl: string;
+  allPosts: PostEntry[];
+};
+
+const { title, description, date, author, heroImage, heroImageAlt, topics, impact_score, canonicalUrl } = post.data;
+const displayDate = formatDate(date);
+const readingTimeLabel = formatReadingMinutes(readingTime);
+const isoDate = date.toISOString();
+const heroAlt = heroImageAlt ?? `${title} hero image`;
+const filteredHeadings = headings.filter((heading) => heading.depth === 2 || heading.depth === 3);
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const primaryCategory = topics?.[0] ? categoryByKey.get(topics[0]) : undefined;
+const categoryLabel = primaryCategory?.label;
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: title,
+  description,
+  image: heroImage.startsWith('http') ? heroImage : new URL(heroImage, canonicalUrl).toString(),
+  datePublished: isoDate,
+  dateModified: isoDate,
+  author: {
+    '@type': 'Person',
+    name: author,
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Survive the AI',
+  },
+  mainEntityOfPage: canonicalUrl,
+};
+---
+<!DOCTYPE html>
+<html lang="en" class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {description && <meta name="description" content={description} />}
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content={title} />
+    {description && <meta property="og:description" content={description} />}
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:image" content={heroImage.startsWith('http') ? heroImage : new URL(heroImage, canonicalUrl).toString()} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    {description && <meta name="twitter:description" content={description} />}
+    <meta name="twitter:image" content={heroImage.startsWith('http') ? heroImage : new URL(heroImage, canonicalUrl).toString()} />
+    <title>{title} · Survive the AI</title>
+    <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
+    <script is:inline>
+      (function() {
+        try {
+          const stored = localStorage.getItem('theme');
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          const useDark = stored ? stored === 'dark' : prefersDark;
+          document.documentElement.classList.toggle('dark', useDark);
+        } catch (e) {
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (prefersDark) document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
+  </head>
+  <body class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100 antialiased">
+    <div class="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+      <div class="lg:grid lg:grid-cols-12 lg:gap-10">
+        <main class="pb-16 space-y-6 sm:space-y-8 lg:col-span-8">
+          <slot name="hero">
+            <HeroImage src={heroImage} alt={heroAlt} />
+          </slot>
+          <header class="space-y-4">
+            <div class="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-500">
+              <span>{categoryLabel ?? 'Key Topic'}</span>
+              <span aria-hidden class="hidden h-1 w-1 rounded-full bg-neutral-300 sm:block" />
+              <span>Impact Score: {impact_score}</span>
+            </div>
+            <slot name="heading">
+              <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl">{title}</h1>
+              {description && <p class="text-base text-neutral-700 sm:text-lg">{description}</p>}
+            </slot>
+            <div class="lg:hidden">
+              <slot name="share-bar-top">
+                <ShareBar client:load url={shareUrl} title={title} className="mt-2" />
+              </slot>
+            </div>
+          </header>
+          <Byline
+            client:idle
+            author={author}
+            displayDate={displayDate}
+            isoDate={isoDate}
+            readingTime={readingTimeLabel}
+          />
+          <slot name="inline-cta" />
+          {filteredHeadings.length > 0 && (
+            <div class="lg:hidden">
+              <TableOfContents client:load headings={filteredHeadings} initiallyCollapsed={true} />
+            </div>
+          )}
+          <article class="mx-auto w-full max-w-[760px] prose prose-neutral text-neutral-900 prose-headings:font-extrabold prose-a:underline-offset-2 dark:prose-invert dark:text-neutral-100">
+            <slot />
+          </article>
+          <footer class="pt-6">
+            <slot name="share-bar-bottom">
+              <ShareBar client:load url={shareUrl} title={title} />
+            </slot>
+          </footer>
+        </main>
+        <aside class="space-y-8 lg:col-span-4">
+          <div class="space-y-8 lg:sticky lg:top-24">
+            <RightRailRelated currentSlug={post.slug} posts={allPosts} />
+            {filteredHeadings.length > 0 && (
+              <div class="hidden lg:block">
+                <TableOfContents client:load headings={filteredHeadings} initiallyCollapsed={false} />
+              </div>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/pages/v2/index.astro
+++ b/src/pages/v2/index.astro
@@ -1,0 +1,151 @@
+---
+import Layout from '../../layouts/BaseLayout.astro';
+import NewsletterSignup from '../../components/NewsletterSignup.astro';
+import { getCollection } from 'astro:content';
+import type { PostEntry } from '../../content/config';
+import { TOPIC_CATEGORIES } from '../../data/categories';
+import { formatDate } from '../../utils/format';
+
+const posts = (await getCollection('posts')).filter((post) => post.data.version === 2);
+posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+const hero = posts.find((post) => post.data.featured);
+const heroSlug = hero?.slug;
+const evergreenPosts = posts.filter((post) => post.data.evergreen && post.slug !== heroSlug).slice(0, 4);
+const excludedSlugs = new Set<string>();
+if (heroSlug) excludedSlugs.add(heroSlug);
+evergreenPosts.forEach((post) => excludedSlugs.add(post.slug));
+const latestPosts = posts.filter((post) => !excludedSlugs.has(post.slug)).slice(0, 5);
+
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const primaryLabel = (entry: PostEntry) => {
+  const key = entry.data.topics?.[0];
+  const category = key ? categoryByKey.get(key) : undefined;
+  return category?.label ?? entry.data.category;
+};
+---
+
+<Layout>
+  <main class="bg-white py-16 text-neutral-900">
+    <div class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8 space-y-16">
+      <section class="space-y-6">
+        <div class="flex items-center justify-between">
+          <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl">SurviveTheAI · V2</h1>
+          <a href="/v2/start-here" class="text-sm font-semibold text-neutral-700 hover:text-neutral-900 underline underline-offset-4">
+            Start Here
+          </a>
+        </div>
+        {hero ? (
+          <article class="grid grid-cols-1 gap-6 rounded-3xl border border-neutral-200 bg-gradient-to-br from-neutral-900 via-neutral-800 to-neutral-700 p-6 text-white shadow-xl md:grid-cols-2">
+            <div class="space-y-4">
+              <p class="text-xs uppercase tracking-[0.35em] text-neutral-300">Featured Insight</p>
+              <h2 class="text-3xl font-extrabold leading-tight sm:text-4xl">{hero.data.title}</h2>
+              <p class="text-base text-neutral-200 sm:text-lg">{hero.data.description}</p>
+              <div class="flex flex-wrap items-center gap-3 text-sm text-neutral-200">
+                <span class="font-semibold">{primaryLabel(hero)}</span>
+                <span aria-hidden class="hidden h-1 w-1 rounded-full bg-neutral-400 sm:block" />
+                <span>Impact {hero.data.impact_score}</span>
+                <span aria-hidden class="hidden h-1 w-1 rounded-full bg-neutral-400 sm:block" />
+                <span>{formatDate(hero.data.date)}</span>
+              </div>
+              <a
+                href={`/v2/posts/${hero.slug}/`}
+                class="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-neutral-900 transition hover:-translate-y-[1px] hover:shadow-lg"
+              >
+                Read the playbook
+              </a>
+            </div>
+            <div class="overflow-hidden rounded-2xl border border-white/10 bg-neutral-900">
+              <img
+                src={hero.data.heroImage}
+                alt={hero.data.heroImageAlt ?? hero.data.title}
+                class="h-full w-full object-cover"
+                loading="lazy"
+                decoding="async"
+                width="1200"
+                height="630"
+              />
+            </div>
+          </article>
+        ) : (
+          <div class="rounded-2xl border border-dashed border-neutral-200 bg-neutral-50 p-6 text-neutral-700">
+            No featured post yet. Add a V2 post with <code class="font-mono">featured: true</code> to highlight it here.
+          </div>
+        )}
+      </section>
+
+      <section class="space-y-8">
+        <div class="flex items-center justify-between">
+          <h2 class="text-2xl font-bold text-neutral-900">Evergreen</h2>
+          <p class="text-sm text-neutral-600">Timeless playbooks that stay relevant</p>
+        </div>
+        {evergreenPosts.length ? (
+          <div class="grid grid-cols-1 gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {evergreenPosts.map((post) => (
+              <a
+                key={post.slug}
+                href={`/v2/posts/${post.slug}/`}
+                class="group flex h-full flex-col overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+              >
+                <div class="h-48 w-full overflow-hidden">
+                  <img
+                    src={post.data.heroImage}
+                    alt={post.data.heroImageAlt ?? post.data.title}
+                    class="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                    loading="lazy"
+                    decoding="async"
+                    width="640"
+                    height="360"
+                  />
+                </div>
+                <div class="flex flex-1 flex-col gap-3 p-5">
+                  <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
+                    <span>{primaryLabel(post)}</span>
+                    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+                    <span>{formatDate(post.data.date)}</span>
+                  </div>
+                  <h3 class="text-lg font-semibold text-neutral-900 group-hover:text-neutral-700">{post.data.title}</h3>
+                  <p class="text-sm text-neutral-700">{post.data.description}</p>
+                </div>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <p class="text-neutral-600">Add up to four evergreen V2 posts to populate this grid.</p>
+        )}
+      </section>
+
+      <section class="space-y-6">
+        <div class="flex items-center justify-between">
+          <h2 class="text-2xl font-bold text-neutral-900">Latest</h2>
+          <p class="text-sm text-neutral-600">Newest drops for V2</p>
+        </div>
+        {latestPosts.length ? (
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+            {latestPosts.map((post) => (
+              <a
+                key={post.slug}
+                href={`/v2/posts/${post.slug}/`}
+                class="group flex h-full flex-col gap-3 rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+              >
+                <div class="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-600">
+                  <span>{primaryLabel(post)}</span>
+                  <span aria-hidden class="hidden h-1 w-1 rounded-full bg-neutral-300 sm:block" />
+                  <span>{formatDate(post.data.date)}</span>
+                </div>
+                <h3 class="text-lg font-semibold text-neutral-900 group-hover:text-neutral-700">{post.data.title}</h3>
+                <p class="text-sm text-neutral-700">{post.data.description}</p>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <p class="text-neutral-600">Latest posts will appear here once V2 content is published.</p>
+        )}
+      </section>
+
+      <section class="rounded-3xl border border-neutral-200 bg-gradient-to-r from-neutral-50 to-white p-8 shadow-sm">
+        <NewsletterSignup />
+      </section>
+    </div>
+  </main>
+</Layout>

--- a/src/pages/v2/posts/[slug].astro
+++ b/src/pages/v2/posts/[slug].astro
@@ -1,0 +1,57 @@
+---
+import { getCollection } from 'astro:content';
+import PostLayout from '../../../layouts/v2/PostLayout.astro';
+import { readingTime } from '../../../utils/readingTime';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('posts');
+  const v2Posts = posts.filter((post) => post.data.version === 2);
+  return v2Posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post, allPosts: v2Posts },
+  }));
+}
+
+const { post, allPosts } = Astro.props;
+const { Content, headings } = await post.render();
+const { minutes } = readingTime(post.body ?? '');
+const shareUrl = post.data.canonicalUrl || new URL(`/v2/posts/${post.slug}/`, Astro.site ?? 'https://survivetheai.com').toString();
+const affiliate = post.data.affiliate_offer;
+---
+<PostLayout
+  post={post}
+  headings={headings}
+  readingTime={minutes}
+  shareUrl={shareUrl}
+  allPosts={allPosts}
+>
+  {affiliate && (
+    <div
+      slot="inline-cta"
+      class="space-y-4 rounded-3xl border border-neutral-200 bg-neutral-50 p-6 shadow-[0_10px_30px_-20px_rgba(0,0,0,0.12)]"
+    >
+      <div class="space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-600">Featured offer</p>
+        <h2 class="text-xl font-semibold text-neutral-900 sm:text-2xl">{affiliate.label}</h2>
+        {affiliate.description && <p class="text-sm text-neutral-700 sm:text-base">{affiliate.description}</p>}
+      </div>
+      <div class="flex flex-col gap-3 sm:flex-row">
+        <a
+          href={affiliate.url}
+          class="inline-flex items-center justify-center rounded-full bg-neutral-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-neutral-800"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Access the offer
+        </a>
+        <a
+          href={shareUrl}
+          class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-5 py-2 text-sm font-semibold text-neutral-800 transition hover:border-neutral-500 hover:text-neutral-900"
+        >
+          Share this playbook
+        </a>
+      </div>
+    </div>
+  )}
+  <Content />
+</PostLayout>

--- a/src/pages/v2/start-here.astro
+++ b/src/pages/v2/start-here.astro
@@ -1,0 +1,65 @@
+---
+import Layout from '../../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+import { TOPIC_CATEGORIES } from '../../data/categories';
+import { formatDate } from '../../utils/format';
+
+const posts = (await getCollection('posts'))
+  .filter((post) => post.data.version === 2 && post.data.start_here)
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const primaryLabel = (topics?: string[], fallback?: string) => {
+  if (!topics || topics.length === 0) return fallback;
+  return categoryByKey.get(topics[0])?.label ?? fallback;
+};
+---
+
+<Layout>
+  <main class="bg-white py-16 text-neutral-900">
+    <div class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8 space-y-10">
+      <header class="space-y-3 text-center sm:text-left">
+        <p class="text-xs uppercase tracking-[0.35em] text-neutral-500">Version 2</p>
+        <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl">Start Here</h1>
+        <p class="text-base text-neutral-700 sm:text-lg">
+          A curated path for SurviveTheAI V2 — hand-picked fundamentals to get you oriented.
+        </p>
+      </header>
+
+      {posts.length ? (
+        <div class="grid grid-cols-1 gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {posts.map((post) => (
+            <a
+              key={post.slug}
+              href={`/v2/posts/${post.slug}/`}
+              class="group flex h-full flex-col overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+            >
+              <div class="h-44 w-full overflow-hidden">
+                <img
+                  src={post.data.heroImage}
+                  alt={post.data.heroImageAlt ?? post.data.title}
+                  class="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                  loading="lazy"
+                  decoding="async"
+                  width="640"
+                  height="360"
+                />
+              </div>
+              <div class="flex flex-1 flex-col gap-3 p-5">
+                <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
+                  <span>{primaryLabel(post.data.topics, post.data.category)}</span>
+                  <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+                  <span>{formatDate(post.data.date)}</span>
+                </div>
+                <h2 class="text-lg font-semibold text-neutral-900 group-hover:text-neutral-700">{post.data.title}</h2>
+                <p class="text-sm text-neutral-700">{post.data.description}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      ) : (
+        <p class="text-neutral-600">Mark V2 posts with <code class="font-mono">start_here: true</code> to feature them here.</p>
+      )}
+    </div>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- extend post schema with versioned flags and add version metadata to existing posts
- seed three v2 sample posts and build version-specific layouts for /v2 and /v2/start-here
- add v2-only post route and layout/components that link to /v2/posts slugs and prevent cross-section duplicates

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958539928ac832685148b866e1d7d3a)