### PR TITLE
Add V2 navigation and blog pagination

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,56 +1,188 @@
-<nav class="bg-zinc-900 text-white">
-  	<div class="mx-auto max-w-7xl px-4 py-4">
-    	<div class="grid grid-cols-4 items-center">
-      	<div class="font-bold text-3xl"><a href="/">Survive the AI</a></div>
-			<div class="col-span-2">
-				<div class="grid grid-cols-4 gap-2">
-				<a href="/"
-					class="text-center font-bold text-xl py-2 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-orange-500">
-					Home
-				</a>
-				<a href="/quiz"
-					class="text-center font-bold text-xl py-2 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-orange-500">
-					Quiz
-				</a>
-				<a href="/drops"
-					class="text-center font-bold text-xl py-2 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-orange-500">
-					Drops
-				</a>
-				<a href="/blog"
-					class="text-center font-bold text-xl py-2 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-orange-500">
-					Fear Papers
-				</a>
-				</div>
-			</div>
-			<div class="flex justify-end gap-3">
-				<button class="p-2 rounded-full hover:bg-white/10">
-					<svg class="w-8 h-8 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-						<path stroke-linecap="round" stroke-linejoin="round" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" />
-						<path stroke-linecap="round" stroke-linejoin="round" d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83
-																				2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33
-																				1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2
-																				2 2 0 0 1-2-2v-.09a1.65 1.65 0 0 0-1-1.51
-																				1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0
-																				2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82
-																				1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2
-																				2 2 0 0 1 2-2h.09a1.65 1.65 0 0 0 1.51-1
-																				1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83
-																				2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9
-																				a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2
-																				2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51
-																				1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0
-																				2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9
-																				a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2
-																				2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-					</svg>
-				</button>
-				<button class="p-2 rounded-full hover:bg-white/10">
-					<svg class="w-8 h-8 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-						<circle cx="12" cy="6" r="4" />
-						<path stroke-linecap="round" stroke-linejoin="round" d="M4 20v-1a5 5 0 0 1 5-5h6a5 5 0 0 1 5 5v1" />
-					</svg>
-				</button>
-			</div>
-    	</div>
-  	</div>
+---
+import { TOPIC_CATEGORIES } from '../data/categories';
+
+const topicCategories = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
+const desktopLinks = [
+  { label: 'Start Here', href: '/v2/start-here' },
+  { label: 'Blog', href: '/v2/blog' },
+  { label: 'Quiz', href: '/quiz' },
+  { label: 'Drops', href: '/drops' },
+  { label: 'Archives', href: '/v1' },
+];
+---
+
+<nav class="sticky top-0 z-40 border-b border-neutral-200 bg-white/90 backdrop-blur relative">
+  <div class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
+    <div class="flex items-center justify-between py-4">
+      <a href="/v2" class="text-xl font-black tracking-tight text-neutral-900">SurviveTheAI</a>
+
+      <!-- Desktop navigation -->
+      <div class="hidden items-center gap-3 lg:flex">
+        {desktopLinks.map((link) => (
+          <a
+            href={link.href}
+            class="rounded-full px-4 py-2 text-sm font-semibold text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+          >
+            {link.label}
+          </a>
+        ))}
+
+        <div class="relative group">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 rounded-full px-4 py-2 text-sm font-semibold text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+          >
+            Topics
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" class="h-4 w-4" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+          <div
+            class="invisible absolute right-0 top-full mt-3 w-80 rounded-2xl border border-neutral-200 bg-white p-3 shadow-2xl opacity-0 transition duration-150 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+          >
+            <div class="space-y-1">
+              {topicCategories.map((category) => (
+                <a
+                  href={`/v2/categories/${category.slug}/`}
+                  class="flex items-start gap-3 rounded-xl px-3 py-2 transition hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+                >
+                  <span
+                    class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold"
+                    style={`background-color:${category.color}1a; color:${category.color};`}
+                  >
+                    {category.icon}
+                  </span>
+                  <span class="space-y-0.5">
+                    <span class="block text-sm font-semibold text-neutral-900">{category.label}</span>
+                    {category.description && <span class="block text-xs text-neutral-600">{category.description}</span>}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile trigger -->
+      <button
+        class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-neutral-200 bg-white text-neutral-900 shadow-sm transition hover:border-neutral-300 hover:bg-neutral-50 lg:hidden"
+        type="button"
+        data-mobile-toggle
+        aria-expanded="false"
+        aria-controls="mobile-nav"
+      >
+        <span class="sr-only">Open navigation</span>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" class="h-6 w-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16M4 12h16M4 17h16" />
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- Mobile slide-in -->
+  <div
+    id="mobile-nav"
+    class="lg:hidden absolute inset-x-0 top-0 origin-top transform rounded-b-3xl border-b border-neutral-200 bg-white shadow-2xl transition-all duration-200 ease-out -translate-y-full opacity-0 pointer-events-none"
+  >
+    <div class="flex items-center justify-between px-4 py-4">
+      <a href="/v2" class="text-lg font-black text-neutral-900">SurviveTheAI</a>
+      <button
+        type="button"
+        class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-neutral-200 bg-white text-neutral-900 shadow-sm transition hover:border-neutral-300 hover:bg-neutral-50"
+        data-mobile-close
+        aria-label="Close menu"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-6 w-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M6 18L18 6" />
+        </svg>
+      </button>
+    </div>
+    <div class="space-y-1 px-4 pb-4">
+      {desktopLinks.map((link) => (
+        <a
+          href={link.href}
+          class="block rounded-2xl px-4 py-3 text-base font-semibold text-neutral-900 transition hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+        >
+          {link.label}
+        </a>
+      ))}
+
+      <div class="rounded-2xl border border-neutral-200 bg-neutral-50 px-4 py-3">
+        <button
+          type="button"
+          class="flex w-full items-center justify-between text-base font-semibold text-neutral-900"
+          data-topics-toggle
+          aria-expanded="false"
+          aria-controls="mobile-topics"
+        >
+          <span>Topics</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" class="h-5 w-5" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+          </svg>
+        </button>
+        <div id="mobile-topics" class="mt-3 hidden space-y-2">
+          {topicCategories.map((category) => (
+            <a
+              href={`/v2/categories/${category.slug}/`}
+              class="flex items-start gap-3 rounded-xl px-3 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+            >
+              <span
+                class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold"
+                style={`background-color:${category.color}1a; color:${category.color};`}
+              >
+                {category.icon}
+              </span>
+              <span class="space-y-0.5">
+                <span class="block">{category.label}</span>
+                {category.description && <span class="block text-xs font-medium text-neutral-600">{category.description}</span>}
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    id="mobile-backdrop"
+    class="lg:hidden fixed inset-0 bg-black/30 opacity-0 transition-opacity duration-200 pointer-events-none"
+    aria-hidden="true"
+  ></div>
 </nav>
+
+<script is:inline>
+  (() => {
+    const mobileToggle = document.querySelector('[data-mobile-toggle]');
+    const mobileClose = document.querySelector('[data-mobile-close]');
+    const panel = document.getElementById('mobile-nav');
+    const backdrop = document.getElementById('mobile-backdrop');
+    const topicsToggle = document.querySelector('[data-topics-toggle]');
+    const topicsList = document.getElementById('mobile-topics');
+
+    const setMenuOpen = (isOpen) => {
+      if (!panel || !backdrop || !mobileToggle) return;
+      mobileToggle.setAttribute('aria-expanded', String(isOpen));
+      panel.classList.toggle('opacity-0', !isOpen);
+      panel.classList.toggle('opacity-100', isOpen);
+      panel.classList.toggle('-translate-y-full', !isOpen);
+      panel.classList.toggle('translate-y-0', isOpen);
+      panel.classList.toggle('pointer-events-none', !isOpen);
+      backdrop.classList.toggle('opacity-0', !isOpen);
+      backdrop.classList.toggle('pointer-events-none', !isOpen);
+    };
+
+    mobileToggle?.addEventListener('click', () => setMenuOpen(true));
+    mobileClose?.addEventListener('click', () => setMenuOpen(false));
+    backdrop?.addEventListener('click', () => setMenuOpen(false));
+
+    topicsToggle?.addEventListener('click', () => {
+      if (!topicsList || !topicsToggle) return;
+      const expanded = topicsToggle.getAttribute('aria-expanded') === 'true';
+      topicsToggle.setAttribute('aria-expanded', String(!expanded));
+      topicsList.classList.toggle('hidden');
+    });
+
+    window.matchMedia('(min-width: 1024px)').addEventListener('change', (event) => {
+      if (event.matches) setMenuOpen(false);
+    });
+  })();
+</script>

--- a/src/components/v2/BlogList.astro
+++ b/src/components/v2/BlogList.astro
@@ -1,0 +1,135 @@
+---
+import type { PostEntry } from '../../content/config';
+import { formatDate } from '../../utils/format';
+import { TOPIC_CATEGORIES } from '../../data/categories';
+
+interface BlogListProps {
+  posts: PostEntry[];
+  currentPage: number;
+  totalPages: number;
+  basePath?: string;
+  title?: string;
+  description?: string;
+  eyebrow?: string;
+}
+
+const {
+  posts,
+  currentPage,
+  totalPages,
+  basePath = '/v2/blog',
+  title = 'All V2 Drops',
+  description = 'Latest SurviveTheAI V2 insights, playbooks, and experiments.',
+  eyebrow = 'Version 2',
+} = Astro.props as BlogListProps;
+
+const toPagePath = (pageNumber: number) => (pageNumber === 1 ? basePath : `${basePath}/page/${pageNumber}`);
+const prevPath = currentPage > 1 ? toPagePath(currentPage - 1) : undefined;
+const nextPath = currentPage < totalPages ? toPagePath(currentPage + 1) : undefined;
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const primaryLabel = (post: PostEntry) => {
+  const key = post.data.topics?.[0];
+  const category = key ? categoryByKey.get(key) : undefined;
+  return category?.label ?? post.data.category ?? 'Topic';
+};
+---
+
+<section class="bg-white py-16 text-neutral-900">
+  <div class="mx-auto max-w-screen-xl space-y-10 px-4 sm:px-6 lg:px-8">
+    <!-- Page heading -->
+    <header class="space-y-3">
+      <p class="text-xs uppercase tracking-[0.35em] text-neutral-500">{eyebrow}</p>
+      <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl">{title}</h1>
+      {description && <p class="text-base text-neutral-700 sm:text-lg">{description}</p>}
+    </header>
+
+    <!-- Post grid -->
+    {posts.length ? (
+      <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => (
+          <a
+            key={post.slug}
+            href={`/v2/posts/${post.slug}/`}
+            class="group flex h-full flex-col overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+          >
+            <div class="h-48 w-full overflow-hidden">
+              <img
+                src={post.data.heroImage}
+                alt={post.data.heroImageAlt ?? post.data.title}
+                class="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                loading="lazy"
+                decoding="async"
+                width="640"
+                height="360"
+              />
+            </div>
+            <div class="flex flex-1 flex-col gap-3 p-5">
+              <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
+                <span>{primaryLabel(post)}</span>
+                <span aria-hidden class="hidden h-1 w-1 rounded-full bg-neutral-300 sm:block" />
+                <span>{formatDate(post.data.date)}</span>
+              </div>
+              <h2 class="text-lg font-semibold text-neutral-900 group-hover:text-neutral-700">{post.data.title}</h2>
+              <p class="text-sm text-neutral-700">{post.data.description}</p>
+            </div>
+          </a>
+        ))}
+      </div>
+    ) : (
+      <div class="rounded-2xl border border-dashed border-neutral-200 bg-neutral-50 p-6 text-neutral-700">
+        No posts found yet for this view.
+      </div>
+    )}
+
+    <!-- Pagination -->
+    {totalPages > 1 && (
+      <nav class="flex flex-col items-center justify-between gap-4 border-t border-neutral-200 pt-6 sm:flex-row">
+        <div class="flex items-center gap-2">
+          {prevPath ? (
+            <a
+              href={prevPath}
+              class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-800 transition hover:border-neutral-300 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+            >
+              ← Previous
+            </a>
+          ) : (
+            <span class="inline-flex items-center gap-2 rounded-full border border-neutral-100 px-4 py-2 text-sm font-semibold text-neutral-400">
+              ← Previous
+            </span>
+          )}
+          {nextPath ? (
+            <a
+              href={nextPath}
+              class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-800 transition hover:border-neutral-300 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+            >
+              Next →
+            </a>
+          ) : (
+            <span class="inline-flex items-center gap-2 rounded-full border border-neutral-100 px-4 py-2 text-sm font-semibold text-neutral-400">
+              Next →
+            </span>
+          )}
+        </div>
+        <div class="flex items-center gap-2">
+          {Array.from({ length: totalPages }).map((_, index) => {
+            const pageNumber = index + 1;
+            const path = toPagePath(pageNumber);
+            const isActive = pageNumber === currentPage;
+            return (
+              <a
+                href={path}
+                class={`inline-flex h-10 w-10 items-center justify-center rounded-full text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800 ${
+                  isActive
+                    ? 'bg-neutral-900 text-white shadow-md'
+                    : 'border border-neutral-200 bg-white text-neutral-800 hover:border-neutral-300 hover:text-neutral-900'
+                }`}
+              >
+                {pageNumber}
+              </a>
+            );
+          })}
+        </div>
+      </nav>
+    )}
+  </div>
+</section>

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -15,7 +15,7 @@ export const TOPIC_CATEGORIES: Category[] = [
   {
     key: "work-money",
     label: "Work & Money – AI Job Displacement",
-    slug: "work-and-money-ai-job-displacement",
+    slug: "work-money-ai-job-displacement",
     order: 1,
     color: "#e63b2e",
     icon: "briefcase",
@@ -24,7 +24,7 @@ export const TOPIC_CATEGORIES: Category[] = [
   {
     key: "kids-school",
     label: "Kids & School – AI vs Your Children’s Future",
-    slug: "kids-and-school-ai-vs-your-childrens-future",
+    slug: "kids-school-ai-vs-your-childrens-future",
     order: 2,
     color: "#f59e0b",
     icon: "school",
@@ -33,7 +33,7 @@ export const TOPIC_CATEGORIES: Category[] = [
   {
     key: "love-connection",
     label: "Love, Sex & Connection – AI Relationships & Synthetic Intimacy",
-    slug: "love-sex-and-connection-ai-relationships-synthetic-intimacy",
+    slug: "love-sex-connection-ai-relationships-synthetic-intimacy",
     order: 3,
     color: "#ec4899",
     icon: "heart",
@@ -42,7 +42,7 @@ export const TOPIC_CATEGORIES: Category[] = [
   {
     key: "mind-attention",
     label: "Mind & Attention – Cognitive Erosion & Offloading",
-    slug: "mind-and-attention-cognitive-erosion-offloading",
+    slug: "mind-attention-cognitive-erosion-offloading",
     order: 4,
     color: "#6366f1",
     icon: "brain",
@@ -51,7 +51,7 @@ export const TOPIC_CATEGORIES: Category[] = [
   {
     key: "system-shock",
     label: "System Shock – Soft Extinction & Collapse",
-    slug: "system-shock-soft-extinction-and-collapse",
+    slug: "system-shock-soft-extinction-collapse",
     order: 5,
     color: "#0ea5e9",
     icon: "alert",

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -6,6 +6,7 @@ import ShareBar from '../components/ShareBar.tsx';
 import TableOfContents from '../components/TableOfContents.tsx';
 import '../styles/tokens.css';
 import '../styles/tailwind.css';
+import Navbar from '../components/Navbar.astro';
 import type { PostEntry } from '../content/config';
 import type { MarkdownHeading } from 'astro';
 import { formatDate, formatReadingMinutes } from '../utils/format';
@@ -89,6 +90,7 @@ const structuredData = {
     </script>
   </head>
   <body class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100 antialiased">
+    <Navbar />
     <div class="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
       <div class="lg:grid lg:grid-cols-12 lg:gap-10">
         <main class="pb-16 space-y-6 sm:space-y-8 lg:col-span-8">

--- a/src/layouts/v2/PostLayout.astro
+++ b/src/layouts/v2/PostLayout.astro
@@ -6,6 +6,7 @@ import ShareBar from '../../components/ShareBar.tsx';
 import TableOfContents from '../../components/TableOfContents.tsx';
 import '../../styles/tokens.css';
 import '../../styles/tailwind.css';
+import Navbar from '../../components/Navbar.astro';
 import type { PostEntry } from '../../content/config';
 import type { MarkdownHeading } from 'astro';
 import { formatDate, formatReadingMinutes } from '../../utils/format';
@@ -89,6 +90,7 @@ const structuredData = {
     </script>
   </head>
   <body class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100 antialiased">
+    <Navbar />
     <div class="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
       <div class="lg:grid lg:grid-cols-12 lg:gap-10">
         <main class="pb-16 space-y-6 sm:space-y-8 lg:col-span-8">

--- a/src/pages/v2/blog/index.astro
+++ b/src/pages/v2/blog/index.astro
@@ -1,0 +1,21 @@
+---
+import Layout from '../../../layouts/BaseLayout.astro';
+import BlogList from '../../../components/v2/BlogList.astro';
+import { getV2Posts } from '../../../utils/getV2Posts';
+
+const PAGE_SIZE = 12;
+const posts = await getV2Posts();
+const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
+const visiblePosts = posts.slice(0, PAGE_SIZE);
+---
+
+<Layout>
+  <BlogList
+    posts={visiblePosts}
+    currentPage={1}
+    totalPages={totalPages}
+    basePath="/v2/blog"
+    title="Blog"
+    description="Browse every SurviveTheAI V2 article in one place."
+  />
+</Layout>

--- a/src/pages/v2/blog/page/[page].astro
+++ b/src/pages/v2/blog/page/[page].astro
@@ -1,0 +1,19 @@
+---
+import Layout from '../../../../layouts/BaseLayout.astro';
+import BlogList from '../../../../components/v2/BlogList.astro';
+import type { Page } from 'astro';
+import type { PostEntry } from '../../../../content/config';
+import { getV2Posts } from '../../../../utils/getV2Posts';
+
+export async function getStaticPaths({ paginate }) {
+  const PAGE_SIZE = 12;
+  const posts = await getV2Posts();
+  return paginate(posts, { pageSize: PAGE_SIZE });
+}
+
+const { page } = Astro.props as { page: Page<PostEntry> };
+---
+
+<Layout>
+  <BlogList posts={page.data} currentPage={page.currentPage} totalPages={page.lastPage} basePath="/v2/blog" />
+</Layout>

--- a/src/pages/v2/categories/[slug].astro
+++ b/src/pages/v2/categories/[slug].astro
@@ -1,0 +1,76 @@
+---
+import Layout from '../../../layouts/BaseLayout.astro';
+import BlogList from '../../../components/v2/BlogList.astro';
+import { TOPIC_CATEGORIES } from '../../../data/categories';
+import { getV2Posts } from '../../../utils/getV2Posts';
+
+export function getStaticPaths() {
+  return TOPIC_CATEGORIES.map((category) => ({
+    params: { slug: category.slug },
+  }));
+}
+
+const slug = Astro.params.slug ?? '';
+const category = TOPIC_CATEGORIES.find((cat) => cat.slug === slug);
+
+if (!category) {
+  throw new Error('Category not found');
+}
+
+const posts = (await getV2Posts()).filter(
+  (post) => Array.isArray(post.data.topics) && (post.data.topics.includes(category.key) || post.data.topics.includes(slug))
+);
+
+const emojiMap: Record<string, string> = {
+  briefcase: '💼',
+  school: '🎒',
+  heart: '❤️',
+  brain: '🧠',
+  alert: '⚠️',
+};
+
+const icon = emojiMap[category.icon] ?? '⭐';
+const title = category.label;
+const description = category.description ?? 'Explore the latest articles in this category.';
+---
+
+<Layout>
+  <main class="bg-white py-16 text-neutral-900">
+    <div class="mx-auto max-w-screen-xl space-y-10 px-4 sm:px-6 lg:px-8">
+      <!-- Category hero -->
+      <header class="flex flex-col gap-4 rounded-3xl border border-neutral-200 bg-gradient-to-r from-white to-neutral-50 p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-center gap-4">
+          <span
+            class="inline-flex h-12 w-12 items-center justify-center rounded-full text-xl"
+            style={`background-color:${category.color}1a; color:${category.color};`}
+            aria-hidden="true"
+          >
+            {icon}
+          </span>
+          <div class="space-y-1">
+            <p class="text-xs uppercase tracking-[0.35em] text-neutral-500">Category</p>
+            <h1 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">{title}</h1>
+            {description && <p class="text-sm text-neutral-700 sm:text-base">{description}</p>}
+          </div>
+        </div>
+        <a
+          href="/v2/blog"
+          class="inline-flex items-center justify-center rounded-full border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-300 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+        >
+          Back to Blog
+        </a>
+      </header>
+
+      <!-- Posts scoped to category -->
+      <BlogList
+        posts={posts}
+        currentPage={1}
+        totalPages={1}
+        basePath={`/v2/categories/${category.slug}`}
+        title="Articles in this topic"
+        description={description}
+        eyebrow={category.label}
+      />
+    </div>
+  </main>
+</Layout>

--- a/src/pages/v2/tags/[tag].astro
+++ b/src/pages/v2/tags/[tag].astro
@@ -1,0 +1,52 @@
+---
+import Layout from '../../../layouts/BaseLayout.astro';
+import BlogList from '../../../components/v2/BlogList.astro';
+import { getV2Posts } from '../../../utils/getV2Posts';
+
+export async function getStaticPaths() {
+  const posts = await getV2Posts();
+  const tags = new Set<string>();
+  posts.forEach((post) => post.data.tags?.forEach((tag) => tags.add(tag)));
+  return Array.from(tags).map((tag) => ({
+    params: { tag },
+  }));
+}
+
+const tagParam = Astro.params.tag ? decodeURIComponent(Astro.params.tag) : '';
+const normalizedTag = tagParam.toLowerCase();
+const posts = (await getV2Posts()).filter((post) =>
+  Array.isArray(post.data.tags) && post.data.tags.some((tag) => tag.toLowerCase() === normalizedTag)
+);
+---
+
+<Layout>
+  <main class="bg-white py-16 text-neutral-900">
+    <div class="mx-auto max-w-screen-xl space-y-10 px-4 sm:px-6 lg:px-8">
+      <!-- Tag hero -->
+      <header class="flex flex-col gap-2 rounded-3xl border border-neutral-200 bg-gradient-to-r from-white to-neutral-50 p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div class="space-y-1">
+          <p class="text-xs uppercase tracking-[0.35em] text-neutral-500">Tag</p>
+          <h1 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">#{tagParam}</h1>
+          <p class="text-sm text-neutral-700 sm:text-base">Articles tagged with “{tagParam}”.</p>
+        </div>
+        <a
+          href="/v2/blog"
+          class="inline-flex items-center justify-center rounded-full border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-300 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+        >
+          Back to Blog
+        </a>
+      </header>
+
+      <!-- Posts scoped to tag -->
+      <BlogList
+        posts={posts}
+        currentPage={1}
+        totalPages={1}
+        basePath={`/v2/tags/${encodeURIComponent(tagParam)}`}
+        title="Tagged posts"
+        description={`Showing SurviveTheAI V2 posts tagged with “${tagParam}”.`}
+        eyebrow={`#${tagParam}`}
+      />
+    </div>
+  </main>
+</Layout>

--- a/src/utils/getV2Posts.ts
+++ b/src/utils/getV2Posts.ts
@@ -1,0 +1,12 @@
+import { getCollection } from 'astro:content';
+import type { PostEntry } from '../content/config';
+
+/**
+ * Retrieve all V2 posts sorted from newest to oldest.
+ */
+export async function getV2Posts(): Promise<PostEntry[]> {
+  const posts = await getCollection('posts');
+  return posts
+    .filter((post) => post.data.version === 2)
+    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+}


### PR DESCRIPTION
## Summary
- add a responsive header with V2 links, topics dropdown, and archives entry
- create V2 blog index pagination plus reusable listing component and helper
- add V2 category and tag routes and surface navigation on post layouts

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585b220ebc83269c710090e583a529)