### PR TITLE
Add v2 responsive fixes and version switcher

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,5 +1,6 @@
 ---
 import { TOPIC_CATEGORIES } from '../data/categories';
+import VersionSwitcher from './VersionSwitcher.astro';
 
 const topicCategories = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
 const desktopLinks = [
@@ -21,16 +22,18 @@ const desktopLinks = [
         {desktopLinks.map((link) => (
           <a
             href={link.href}
-            class="rounded-full px-4 py-2 text-sm font-semibold text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+            class="tap-target h-12 rounded-full px-4 py-2 text-base font-semibold text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900"
           >
             {link.label}
           </a>
         ))}
 
+        <VersionSwitcher />
+
         <div class="relative group">
           <button
             type="button"
-            class="inline-flex items-center gap-1 rounded-full px-4 py-2 text-sm font-semibold text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+            class="tap-target h-12 gap-1 rounded-full px-4 py-2 text-base font-semibold text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900"
           >
             Topics
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" class="h-4 w-4" stroke="currentColor" stroke-width="2">
@@ -44,7 +47,7 @@ const desktopLinks = [
               {topicCategories.map((category) => (
                 <a
                   href={`/v2/categories/${category.slug}/`}
-                  class="flex items-start gap-3 rounded-xl px-3 py-2 transition hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+                  class="tap-target w-full items-start gap-3 rounded-xl px-3 py-2 text-base transition hover:bg-neutral-50"
                 >
                   <span
                     class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold"
@@ -53,8 +56,8 @@ const desktopLinks = [
                     {category.icon}
                   </span>
                   <span class="space-y-0.5">
-                    <span class="block text-sm font-semibold text-neutral-900">{category.label}</span>
-                    {category.description && <span class="block text-xs text-neutral-600">{category.description}</span>}
+                    <span class="block text-base font-semibold text-neutral-900">{category.label}</span>
+                    {category.description && <span class="block text-sm text-neutral-600">{category.description}</span>}
                   </span>
                 </a>
               ))}
@@ -65,7 +68,7 @@ const desktopLinks = [
 
       <!-- Mobile trigger -->
       <button
-        class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-neutral-200 bg-white text-neutral-900 shadow-sm transition hover:border-neutral-300 hover:bg-neutral-50 lg:hidden"
+        class="tap-target h-12 w-12 rounded-full border border-neutral-200 bg-white text-neutral-900 shadow-sm transition hover:border-neutral-300 hover:bg-neutral-50 lg:hidden"
         type="button"
         data-mobile-toggle
         aria-expanded="false"
@@ -88,7 +91,7 @@ const desktopLinks = [
       <a href="/v2" class="text-lg font-black text-neutral-900">SurviveTheAI</a>
       <button
         type="button"
-        class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-neutral-200 bg-white text-neutral-900 shadow-sm transition hover:border-neutral-300 hover:bg-neutral-50"
+        class="tap-target h-12 w-12 rounded-full border border-neutral-200 bg-white text-neutral-900 shadow-sm transition hover:border-neutral-300 hover:bg-neutral-50"
         data-mobile-close
         aria-label="Close menu"
       >
@@ -101,16 +104,20 @@ const desktopLinks = [
       {desktopLinks.map((link) => (
         <a
           href={link.href}
-          class="block rounded-2xl px-4 py-3 text-base font-semibold text-neutral-900 transition hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+          class="tap-target w-full rounded-2xl px-4 py-3 text-base font-semibold text-neutral-900 transition hover:bg-neutral-50"
         >
           {link.label}
         </a>
       ))}
 
+      <div class="pt-2">
+        <VersionSwitcher />
+      </div>
+
       <div class="rounded-2xl border border-neutral-200 bg-neutral-50 px-4 py-3">
         <button
           type="button"
-          class="flex w-full items-center justify-between text-base font-semibold text-neutral-900"
+          class="tap-target w-full items-center justify-between text-base font-semibold text-neutral-900"
           data-topics-toggle
           aria-expanded="false"
           aria-controls="mobile-topics"
@@ -124,17 +131,17 @@ const desktopLinks = [
           {topicCategories.map((category) => (
             <a
               href={`/v2/categories/${category.slug}/`}
-              class="flex items-start gap-3 rounded-xl px-3 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+              class="tap-target w-full items-start gap-3 rounded-xl px-3 py-2 text-base font-semibold text-neutral-900 transition hover:bg-white"
             >
               <span
-                class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold"
+                class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold"
                 style={`background-color:${category.color}1a; color:${category.color};`}
               >
                 {category.icon}
               </span>
               <span class="space-y-0.5">
                 <span class="block">{category.label}</span>
-                {category.description && <span class="block text-xs font-medium text-neutral-600">{category.description}</span>}
+                {category.description && <span class="block text-sm font-medium text-neutral-600">{category.description}</span>}
               </span>
             </a>
           ))}

--- a/src/components/ShareBar.tsx
+++ b/src/components/ShareBar.tsx
@@ -35,7 +35,7 @@ const ShareBar: FC<ShareBarProps> = ({ url, title, className = '', direction = '
       <button
         type="button"
         onClick={handleCopy}
-        className="flex items-center gap-2 rounded-full border border-neutral-300 bg-white px-4 py-2 text-sm text-neutral-800 transition hover:border-neutral-500 hover:text-neutral-900"
+        className="tap-target items-center gap-2 rounded-full border border-neutral-300 bg-white px-4 py-2 text-base text-neutral-800 transition hover:border-neutral-500 hover:text-neutral-900"
       >
         <svg aria-hidden className={iconClasses} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M8 8h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-9a2 2 0 0 1 2-2z" />
@@ -47,7 +47,7 @@ const ShareBar: FC<ShareBarProps> = ({ url, title, className = '', direction = '
         href={shareLinks.x}
         target="_blank"
         rel="noreferrer noopener"
-        className="flex items-center gap-2 rounded-full border border-neutral-300 bg-white px-4 py-2 text-sm text-neutral-800 transition hover:border-neutral-500 hover:text-neutral-900"
+        className="tap-target items-center gap-2 rounded-full border border-neutral-300 bg-white px-4 py-2 text-base text-neutral-800 transition hover:border-neutral-500 hover:text-neutral-900"
       >
         <svg aria-hidden className={iconClasses} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M20 4.5c-.7.3-1.4.5-2.2.6a3.8 3.8 0 0 0 1.7-2.1 7.8 7.8 0 0 1-2.4.9A3.8 3.8 0 0 0 12 7.4c0 .3 0 .6.1.9A10.8 10.8 0 0 1 4.5 3.5a3.8 3.8 0 0 0 1.2 5.1 3.7 3.7 0 0 1-1.7-.5v.1a3.8 3.8 0 0 0 3 3.7 3.9 3.9 0 0 1-1.7.1 3.8 3.8 0 0 0 3.6 2.7A7.7 7.7 0 0 1 3 18c-.6 0-1.1 0-1.7-.1A10.9 10.9 0 0 0 7.6 20a10.8 10.8 0 0 0 11-11v-.5A7.7 7.7 0 0 0 20 4.5z" />
@@ -58,7 +58,7 @@ const ShareBar: FC<ShareBarProps> = ({ url, title, className = '', direction = '
         href={shareLinks.linkedin}
         target="_blank"
         rel="noreferrer noopener"
-        className="flex items-center gap-2 rounded-full border border-neutral-300 bg-white px-4 py-2 text-sm text-neutral-800 transition hover:border-neutral-500 hover:text-neutral-900"
+        className="tap-target items-center gap-2 rounded-full border border-neutral-300 bg-white px-4 py-2 text-base text-neutral-800 transition hover:border-neutral-500 hover:text-neutral-900"
       >
         <svg aria-hidden className={iconClasses} viewBox="0 0 24 24" fill="currentColor">
           <path d="M4.98 3.5a2 2 0 1 1 .02 4 2 2 0 0 1-.02-4zM3 8.75h3.95V21H3zM9.5 8.75H13v1.67h.05c.49-.92 1.69-1.9 3.48-1.9 3.72 0 4.4 2.25 4.4 5.18V21H16.9v-5.6c0-1.33-.03-3.04-1.86-3.04-1.86 0-2.15 1.45-2.15 2.95V21H9.5z" />

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -37,7 +37,7 @@ const TableOfContents: FC<TableOfContentsProps> = ({
     >
       <button
         type="button"
-        className="flex w-full items-center justify-between gap-2 text-left font-medium text-neutral-800 dark:text-neutral-100 lg:cursor-auto"
+        className="tap-target w-full items-center justify-between gap-2 text-left font-medium text-neutral-800 dark:text-neutral-100 lg:cursor-auto"
         onClick={() => setCollapsed((value) => !value)}
         aria-expanded={!collapsed}
       >
@@ -57,7 +57,7 @@ const TableOfContents: FC<TableOfContentsProps> = ({
           <li key={heading.slug} className={heading.depth === 3 ? 'pl-4 text-neutral-500 dark:text-neutral-400' : ''}>
             <a
               href={`#${heading.slug}`}
-              className="block rounded-md px-2 py-1 transition hover:text-neutral-900 dark:hover:text-neutral-100"
+              className="tap-target w-full justify-start rounded-md px-2 text-base transition hover:text-neutral-900 dark:hover:text-neutral-100"
             >
               {heading.text}
             </a>

--- a/src/components/VersionSwitcher.astro
+++ b/src/components/VersionSwitcher.astro
@@ -1,0 +1,115 @@
+---
+// VersionSwitcher renders a compact control for toggling between the live (v2) and archive (v1) experiences.
+// The component defaults to a dropdown on mobile to save space and shows an inline pill on desktop.
+const currentPath =
+  Astro.url?.pathname ??
+  (Astro.request?.url ? new URL(Astro.request.url).pathname : '');
+const activeKey = currentPath.startsWith('/v1') ? 'v1' : 'v2';
+
+const versions = [
+  { key: 'v2', label: 'v2 🔥', href: '/v2', description: 'Latest experience' },
+  { key: 'v1', label: 'v1', href: '/v1', description: 'Archive view' },
+];
+---
+<div class="relative flex items-center" data-testid="version-switcher">
+  <div class="hidden items-center gap-2 rounded-full border border-neutral-200 bg-white p-1 shadow-sm lg:flex">
+    {versions.map((version) => {
+      const isActive = version.key === activeKey;
+      return (
+        <a
+          href={version.href}
+          class={`tap-target min-w-[88px] justify-center rounded-full px-4 py-2 text-base font-semibold ${
+            isActive ? 'bg-neutral-900 text-white shadow-sm' : 'text-neutral-800 hover:bg-neutral-50'
+          }`}
+          aria-pressed={isActive}
+        >
+          <span class="flex items-center gap-2">
+            <span>{version.label}</span>
+            {version.key === 'v2' && <span class="rounded-full bg-amber-100 px-2 py-1 text-xs font-semibold text-amber-700">Latest</span>}
+          </span>
+        </a>
+      );
+    })}
+  </div>
+
+  <div class="relative w-full max-w-[220px] lg:hidden">
+    <button
+      type="button"
+      class="tap-target w-full justify-between rounded-2xl border border-neutral-200 bg-white px-4 py-3 text-base font-semibold text-neutral-900 shadow-sm"
+      data-version-toggle
+      aria-haspopup="true"
+      aria-expanded="false"
+      aria-controls="version-menu"
+    >
+      <span class="flex items-center gap-2">
+        <span class="inline-flex h-8 min-w-[48px] items-center justify-center rounded-full bg-neutral-900 px-2 text-sm font-semibold text-white">{activeKey.toUpperCase()}</span>
+        <span>Switch version</span>
+      </span>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-5 w-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
+      </svg>
+    </button>
+    <div
+      id="version-menu"
+      data-version-menu
+      class="absolute right-0 z-20 mt-2 w-full min-w-[180px] space-y-2 rounded-2xl border border-neutral-200 bg-white p-2 shadow-xl transition duration-150 ease-out opacity-0 pointer-events-none"
+    >
+      {versions.map((version) => {
+        const isActive = version.key === activeKey;
+        return (
+          <a
+            href={version.href}
+            class={`tap-target w-full justify-between rounded-xl px-4 py-3 text-base font-semibold ${
+              isActive ? 'bg-neutral-900 text-white shadow-sm' : 'text-neutral-800 hover:bg-neutral-50'
+            }`}
+            aria-pressed={isActive}
+          >
+            <span class="flex items-center gap-2">
+              <span>{version.label}</span>
+              {version.key === 'v2' && <span class="rounded-full bg-amber-100 px-2 py-1 text-xs font-semibold text-amber-700">Latest</span>}
+            </span>
+            <span class="text-sm font-medium text-neutral-500">{version.description}</span>
+          </a>
+        );
+      })}
+    </div>
+  </div>
+</div>
+
+<script is:inline>
+  (() => {
+    const toggle = document.querySelector('[data-version-toggle]');
+    const menu = document.querySelector('[data-version-menu]');
+
+    if (!toggle || !menu) return;
+
+    const closeMenu = () => {
+      menu.classList.add('opacity-0', 'pointer-events-none');
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+
+    const openMenu = () => {
+      menu.classList.remove('opacity-0', 'pointer-events-none');
+      toggle.setAttribute('aria-expanded', 'true');
+    };
+
+    const handleToggle = () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      if (expanded) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    };
+
+    toggle.addEventListener('click', handleToggle);
+
+    document.addEventListener('click', (event) => {
+      if (!menu.contains(event.target) && !toggle.contains(event.target)) {
+        closeMenu();
+      }
+    });
+
+    window.addEventListener('resize', closeMenu);
+  })();
+</script>

--- a/src/components/v2/BlogList.astro
+++ b/src/components/v2/BlogList.astro
@@ -1,4 +1,5 @@
 ---
+// BlogList renders a responsive grid of V2 posts with pagination controls and ensures cards collapse to one column on small screens.
 import type { PostEntry } from '../../content/config';
 import { formatDate } from '../../utils/format';
 import { TOPIC_CATEGORIES } from '../../data/categories';
@@ -88,24 +89,24 @@ const primaryLabel = (post: PostEntry) => {
           {prevPath ? (
             <a
               href={prevPath}
-              class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-800 transition hover:border-neutral-300 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+              class="tap-target inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-base font-semibold text-neutral-800 transition hover:border-neutral-300 hover:text-neutral-900"
             >
               ← Previous
             </a>
           ) : (
-            <span class="inline-flex items-center gap-2 rounded-full border border-neutral-100 px-4 py-2 text-sm font-semibold text-neutral-400">
+            <span class="inline-flex min-h-12 items-center gap-2 rounded-full border border-neutral-100 px-4 py-2 text-base font-semibold text-neutral-400">
               ← Previous
             </span>
           )}
           {nextPath ? (
             <a
               href={nextPath}
-              class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-800 transition hover:border-neutral-300 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+              class="tap-target inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-base font-semibold text-neutral-800 transition hover:border-neutral-300 hover:text-neutral-900"
             >
               Next →
             </a>
           ) : (
-            <span class="inline-flex items-center gap-2 rounded-full border border-neutral-100 px-4 py-2 text-sm font-semibold text-neutral-400">
+            <span class="inline-flex min-h-12 items-center gap-2 rounded-full border border-neutral-100 px-4 py-2 text-base font-semibold text-neutral-400">
               Next →
             </span>
           )}
@@ -118,7 +119,7 @@ const primaryLabel = (post: PostEntry) => {
             return (
               <a
                 href={path}
-                class={`inline-flex h-10 w-10 items-center justify-center rounded-full text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800 ${
+                class={`tap-target inline-flex h-12 w-12 items-center justify-center rounded-full text-base font-semibold transition ${
                   isActive
                     ? 'bg-neutral-900 text-white shadow-md'
                     : 'border border-neutral-200 bg-white text-neutral-800 hover:border-neutral-300 hover:text-neutral-900'

--- a/src/components/v2/RightRailRelated.astro
+++ b/src/components/v2/RightRailRelated.astro
@@ -1,4 +1,5 @@
 ---
+// RightRailRelated surfaces the most relevant additional V2 posts and collapses behind the sidebar breakpoint on mobile.
 import type { PostEntry } from '../../content/config';
 import { formatDate } from '../../utils/format';
 import { TOPIC_CATEGORIES } from '../../data/categories';
@@ -37,7 +38,10 @@ const related = (relatedPool.length >= 3 ? relatedPool : sortedPosts).slice(0, 5
 
       return (
         <li>
-          <a href={`/v2/posts/${entry.slug}/`} class="group flex items-center gap-4 rounded-2xl border border-neutral-200 p-2 transition hover:border-neutral-300 hover:bg-neutral-50">
+          <a
+            href={`/v2/posts/${entry.slug}/`}
+            class="tap-target group w-full items-center justify-start gap-4 rounded-2xl border border-neutral-200 px-3 py-2 transition hover:border-neutral-300 hover:bg-neutral-50"
+          >
             <div class="h-14 w-14 overflow-hidden rounded-xl bg-neutral-100">
               <img
                 src={heroImage}
@@ -50,11 +54,11 @@ const related = (relatedPool.length >= 3 ? relatedPool : sortedPosts).slice(0, 5
               />
             </div>
             <div class="space-y-1">
-              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">{label}</p>
-              <p class="text-sm font-medium text-neutral-900 transition group-hover:text-neutral-700">
+              <p class="text-sm font-semibold uppercase tracking-[0.25em] text-neutral-500">{label}</p>
+              <p class="text-base font-medium text-neutral-900 transition group-hover:text-neutral-700">
                 {entry.data.title}
               </p>
-              <p class="text-xs text-neutral-600">{dateLabel}</p>
+              <p class="text-sm text-neutral-600">{dateLabel}</p>
             </div>
           </a>
         </li>

--- a/src/layouts/v2/PostLayout.astro
+++ b/src/layouts/v2/PostLayout.astro
@@ -1,4 +1,5 @@
 ---
+// PostLayout orchestrates the v2 article experience with responsive TOC, share controls, and a sidebar that reappears on large screens.
 import HeroImage from '../../components/HeroImage.astro';
 import Byline from '../../components/Byline.tsx';
 import RightRailRelated from '../../components/v2/RightRailRelated.astro';
@@ -135,7 +136,7 @@ const structuredData = {
             </slot>
           </footer>
         </main>
-        <aside class="space-y-8 lg:col-span-4">
+        <aside class="hidden space-y-8 lg:col-span-4 lg:block">
           <div class="space-y-8 lg:sticky lg:top-24">
             <RightRailRelated currentSlug={post.slug} posts={allPosts} />
             {filteredHeadings.length > 0 && (

--- a/src/pages/v2/categories/[slug].astro
+++ b/src/pages/v2/categories/[slug].astro
@@ -55,7 +55,7 @@ const description = category.description ?? 'Explore the latest articles in this
         </div>
         <a
           href="/v2/blog"
-          class="inline-flex items-center justify-center rounded-full border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-300 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+          class="tap-target justify-center rounded-full border border-neutral-200 px-4 py-2 text-base font-semibold text-neutral-900 transition hover:border-neutral-300 hover:text-neutral-900"
         >
           Back to Blog
         </a>

--- a/src/pages/v2/index.astro
+++ b/src/pages/v2/index.astro
@@ -28,10 +28,13 @@ const primaryLabel = (entry: PostEntry) => {
 <Layout>
   <main class="bg-white py-16 text-neutral-900">
     <div class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8 space-y-16">
-      <section class="space-y-6">
+      <section class="space-y-6" data-testid="home-hero">
         <div class="flex items-center justify-between">
           <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl">SurviveTheAI · V2</h1>
-          <a href="/v2/start-here" class="text-sm font-semibold text-neutral-700 hover:text-neutral-900 underline underline-offset-4">
+          <a
+            href="/v2/start-here"
+            class="tap-target h-12 rounded-full border border-neutral-200 px-4 py-2 text-base font-semibold text-neutral-700 transition hover:bg-neutral-50 hover:text-neutral-900"
+          >
             Start Here
           </a>
         </div>
@@ -50,7 +53,7 @@ const primaryLabel = (entry: PostEntry) => {
               </div>
               <a
                 href={`/v2/posts/${hero.slug}/`}
-                class="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-neutral-900 transition hover:-translate-y-[1px] hover:shadow-lg"
+                class="tap-target justify-center rounded-full bg-white px-5 py-2 text-base font-semibold text-neutral-900 transition hover:-translate-y-[1px] hover:shadow-lg"
               >
                 Read the playbook
               </a>
@@ -74,7 +77,7 @@ const primaryLabel = (entry: PostEntry) => {
         )}
       </section>
 
-      <section class="space-y-8">
+      <section class="space-y-8" data-testid="home-evergreen">
         <div class="flex items-center justify-between">
           <h2 class="text-2xl font-bold text-neutral-900">Evergreen</h2>
           <p class="text-sm text-neutral-600">Timeless playbooks that stay relevant</p>
@@ -115,7 +118,7 @@ const primaryLabel = (entry: PostEntry) => {
         )}
       </section>
 
-      <section class="space-y-6">
+      <section class="space-y-6" data-testid="home-latest">
         <div class="flex items-center justify-between">
           <h2 class="text-2xl font-bold text-neutral-900">Latest</h2>
           <p class="text-sm text-neutral-600">Newest drops for V2</p>
@@ -143,7 +146,7 @@ const primaryLabel = (entry: PostEntry) => {
         )}
       </section>
 
-      <section class="rounded-3xl border border-neutral-200 bg-gradient-to-r from-neutral-50 to-white p-8 shadow-sm">
+      <section class="rounded-3xl border border-neutral-200 bg-gradient-to-r from-neutral-50 to-white p-8 shadow-sm" data-testid="home-newsletter">
         <NewsletterSignup />
       </section>
     </div>

--- a/src/pages/v2/tags/[tag].astro
+++ b/src/pages/v2/tags/[tag].astro
@@ -31,7 +31,7 @@ const posts = (await getV2Posts()).filter((post) =>
         </div>
         <a
           href="/v2/blog"
-          class="inline-flex items-center justify-center rounded-full border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-300 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800"
+          class="tap-target justify-center rounded-full border border-neutral-200 px-4 py-2 text-base font-semibold text-neutral-900 transition hover:border-neutral-300 hover:text-neutral-900"
         >
           Back to Blog
         </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,6 +8,7 @@ body {
   background: inherit;
   color: inherit;
   font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
+  overflow-x: hidden;
 }
 h1, h2, h3, h4, h5 {
   font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
@@ -20,4 +21,10 @@ a {
 }
 a:hover {
   color: var(--accent);
+}
+
+@layer components {
+  .tap-target {
+    @apply inline-flex min-h-12 items-center justify-center rounded-full px-4 py-3 text-base font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-800;
+  }
 }


### PR DESCRIPTION
## Summary
- add a responsive version switcher and surface it across desktop and mobile navigation
- tighten v2 layouts for mobile, including tap-friendly controls, sidebar/TOC behavior, and data-testid hooks for home sections
- refresh share/pagination controls and global styling to avoid horizontal scroll while keeping grids stacked cleanly

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585f6ab61483269a6e0e96c32cac04)