### PR TITLE
Finalize homepage layout, posts index/pagination, nav cleanup, and add Playwright tests

### DIFF
--- a/.astro/collections/posts.schema.json
+++ b/.astro/collections/posts.schema.json
@@ -29,6 +29,15 @@
         "author": {
           "type": "string"
         },
+        "draft": {
+          "type": "boolean"
+        },
+        "featured": {
+          "type": "boolean"
+        },
+        "evergreen": {
+          "type": "boolean"
+        },
         "category": {
           "type": "string"
         },
@@ -58,6 +67,9 @@
           "maximum": 100
         },
         "heroImage": {
+          "type": "string"
+        },
+        "heroImageThumb": {
           "type": "string"
         },
         "heroImageAlt": {

--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -204,6 +204,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("./../src/content/config.js");
+	export type ContentConfig = typeof import("../src/content/config.js");
 	export type LiveContentConfig = never;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "playwright test"
   },
   "dependencies": {
     "@astrojs/react": "^3.0.0",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@astrojs/tailwind": "^6.0.2",
     "@tailwindcss/typography": "^0.5.19",
+    "@playwright/test": "^1.50.1",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "rehype-autolink-headings": "^7.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:4321',
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+  },
+  webServer: {
+    command: 'npm run dev -- --host --port 4321',
+    url: 'http://127.0.0.1:4321',
+    reuseExistingServer: true,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+});

--- a/src/components/BlogList.astro
+++ b/src/components/BlogList.astro
@@ -1,0 +1,95 @@
+---
+import type { PostEntry } from '../content/config';
+import { formatDate } from '../utils/format';
+import { TOPIC_CATEGORIES } from '../data/categories';
+
+const { posts, currentPage, totalPages, basePath } = Astro.props as {
+  posts: PostEntry[];
+  currentPage: number;
+  totalPages: number;
+  basePath: string;
+};
+
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const normalizedBasePath = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+const buildPageHref = (page: number) => (page === 1 ? `${normalizedBasePath}/` : `${normalizedBasePath}/page/${page}/`);
+---
+
+<div class="space-y-8" data-testid="blog-list">
+  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    {posts.map((post) => {
+      const primaryCategory = post.data.topics?.[0] ? categoryByKey.get(post.data.topics[0]) : undefined;
+      return (
+        <article class="flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300">
+          <a href={`/posts/${post.slug}/`} class="block">
+            <img
+              src={post.data.heroImageThumb ?? post.data.heroImage}
+              alt={post.data.heroImageAlt ?? post.data.title}
+              class="h-48 w-full object-cover"
+              loading="lazy"
+              decoding="async"
+              width="640"
+              height="360"
+            />
+          </a>
+          <div class="flex flex-1 flex-col gap-3 p-5">
+            <div class="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-500">
+              <span>{primaryCategory?.label ?? post.data.category ?? 'Key Topic'}</span>
+              <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+              <span>{formatDate(post.data.date)}</span>
+            </div>
+            <h3 class="text-lg font-semibold text-neutral-900">
+              <a href={`/posts/${post.slug}/`} class="transition hover:text-neutral-700">
+                {post.data.title}
+              </a>
+            </h3>
+            <p class="text-sm text-neutral-700">{post.data.description}</p>
+          </div>
+        </article>
+      );
+    })}
+  </div>
+
+  {totalPages > 1 && (
+    <nav class="flex flex-wrap items-center justify-center gap-2 text-sm font-semibold" aria-label="Pagination" data-testid="pagination">
+      <a
+        class={`rounded-full border px-3 py-1 transition ${
+          currentPage > 1
+            ? 'border-neutral-300 text-neutral-800 hover:border-neutral-500 hover:text-neutral-950'
+            : 'cursor-not-allowed border-neutral-200 text-neutral-400'
+        }`}
+        aria-disabled={currentPage === 1}
+        href={currentPage > 1 ? buildPageHref(currentPage - 1) : undefined}
+      >
+        Previous
+      </a>
+      {Array.from({ length: totalPages }, (_, index) => {
+        const page = index + 1;
+        const isActive = page === currentPage;
+        return (
+          <a
+            href={buildPageHref(page)}
+            class={`min-w-[44px] rounded-full px-3 py-1 text-center transition ${
+              isActive
+                ? 'bg-neutral-900 text-white'
+                : 'border border-neutral-300 text-neutral-800 hover:border-neutral-500 hover:text-neutral-950'
+            }`}
+          >
+            {page}
+          </a>
+        );
+      })}
+      <a
+        class={`rounded-full border px-3 py-1 transition ${
+          currentPage < totalPages
+            ? 'border-neutral-300 text-neutral-800 hover:border-neutral-500 hover:text-neutral-950'
+            : 'cursor-not-allowed border-neutral-200 text-neutral-400'
+        }`}
+        aria-disabled={currentPage === totalPages}
+        href={currentPage < totalPages ? buildPageHref(currentPage + 1) : undefined}
+      >
+        Next
+      </a>
+    </nav>
+  )}
+</div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,6 +6,7 @@
     <div class="text-gray-700 font-semibold">© Survive the AI</div>
     <nav class="flex flex-wrap gap-4 text-gray-500 font-medium">
       <a href="/" class="hover:text-blue-600 transition">Home</a>
+      <a href="/posts" class="hover:text-blue-600 transition">All Posts</a>
       <a href="/privacy" class="hover:text-blue-600 transition">Privacy</a>
       <a href="/terms" class="hover:text-blue-600 transition">Terms</a>
     </nav>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,56 +1,59 @@
-<nav class="bg-zinc-900 text-white">
-  	<div class="mx-auto max-w-7xl px-4 py-4">
-    	<div class="grid grid-cols-4 items-center">
-      	<div class="font-bold text-3xl"><a href="/">Survive the AI</a></div>
-			<div class="col-span-2">
-				<div class="grid grid-cols-4 gap-2">
-				<a href="/"
-					class="text-center font-bold text-xl py-2 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-orange-500">
-					Home
-				</a>
-				<a href="/quiz"
-					class="text-center font-bold text-xl py-2 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-orange-500">
-					Quiz
-				</a>
-				<a href="/drops"
-					class="text-center font-bold text-xl py-2 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-orange-500">
-					Drops
-				</a>
-				<a href="/blog"
-					class="text-center font-bold text-xl py-2 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-orange-500">
-					Fear Papers
-				</a>
-				</div>
-			</div>
-			<div class="flex justify-end gap-3">
-				<button class="p-2 rounded-full hover:bg-white/10">
-					<svg class="w-8 h-8 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-						<path stroke-linecap="round" stroke-linejoin="round" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" />
-						<path stroke-linecap="round" stroke-linejoin="round" d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83
-																				2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33
-																				1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2
-																				2 2 0 0 1-2-2v-.09a1.65 1.65 0 0 0-1-1.51
-																				1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0
-																				2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82
-																				1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2
-																				2 2 0 0 1 2-2h.09a1.65 1.65 0 0 0 1.51-1
-																				1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83
-																				2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9
-																				a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2
-																				2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51
-																				1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0
-																				2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9
-																				a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2
-																				2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-					</svg>
-				</button>
-				<button class="p-2 rounded-full hover:bg-white/10">
-					<svg class="w-8 h-8 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-						<circle cx="12" cy="6" r="4" />
-						<path stroke-linecap="round" stroke-linejoin="round" d="M4 20v-1a5 5 0 0 1 5-5h6a5 5 0 0 1 5 5v1" />
-					</svg>
-				</button>
-			</div>
-    	</div>
-  	</div>
+---
+const links = [
+  { href: '/', label: 'Home' },
+  { href: '/posts', label: 'All Posts' },
+  { href: '/drops', label: 'Drops' },
+];
+---
+<nav class="bg-zinc-900 text-white" data-testid="navbar">
+  <div class="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4">
+    <a href="/" class="flex items-center gap-2 text-2xl font-bold tracking-tight hover:text-orange-200 transition">
+      Survive the AI
+    </a>
+    <div class="hidden items-center gap-2 md:flex">
+      {links.map((link) => (
+        <a
+          href={link.href}
+          class="rounded-full px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+        >
+          {link.label}
+        </a>
+      ))}
+    </div>
+    <button
+      type="button"
+      class="inline-flex items-center justify-center rounded-full p-2 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 md:hidden"
+      aria-label="Toggle navigation menu"
+      aria-expanded="false"
+      data-menu-toggle
+      data-testid="mobile-menu-toggle"
+    >
+      <svg class="h-7 w-7" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+  </div>
+  <div id="mobile-menu" class="hidden border-t border-white/10 bg-zinc-900 md:hidden" data-testid="mobile-menu">
+    <div class="mx-auto flex max-w-7xl flex-col gap-2 px-4 py-4">
+      {links.map((link) => (
+        <a
+          href={link.href}
+          class="rounded-xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+        >
+          {link.label}
+        </a>
+      ))}
+    </div>
+  </div>
 </nav>
+<script is:inline>
+  const toggle = document.querySelector('[data-menu-toggle]');
+  const mobileMenu = document.getElementById('mobile-menu');
+
+  if (toggle && mobileMenu) {
+    toggle.addEventListener('click', () => {
+      const isHidden = mobileMenu.classList.toggle('hidden');
+      toggle.setAttribute('aria-expanded', (!isHidden).toString());
+    });
+  }
+</script>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -5,6 +5,9 @@ export const postSchema = z.object({
   description: z.string(),
   date: z.coerce.date(),
   author: z.string(),
+  draft: z.boolean().optional(),
+  featured: z.boolean().optional(),
+  evergreen: z.boolean().optional(),
   category: z.string().optional(),
   topics: z.array(
     z.enum([
@@ -18,6 +21,7 @@ export const postSchema = z.object({
   tags: z.array(z.string()).min(1),
   impact_score: z.number().min(0).max(100),
   heroImage: z.string(),
+  heroImageThumb: z.string().optional(),
   heroImageAlt: z.string().optional(),
   affiliate_offer: z.object({
     label: z.string(),

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,14 @@
 import Navbar from '../components/Navbar.astro';
 import Footer from '../components/Footer.astro';
 import '../styles/global.css';
+
+const {
+  title = 'Survive the AI',
+  description = 'Survive the AI — Tools, strategies, and content to prepare for the AI disruption.',
+} = Astro.props as {
+  title?: string;
+  description?: string;
+};
 ---
 
 <!DOCTYPE html>
@@ -9,8 +17,8 @@ import '../styles/global.css';
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Survive the AI — Tools, strategies, and content to prepare for the AI disruption." />
-    <title>Survive the AI</title>
+    <meta name="description" content={description} />
+    <title>{title}</title>
     <script is:inline>
       (function() {
         try {

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,31 +1,16 @@
 ---
 import Layout from '../layouts/BaseLayout.astro';
-import PostGrid from '../components/PostGrid.astro';
-import { getCollection } from 'astro:content';
-import type { Post } from '../data/Posts';
-
-function chunkArray<T>(arr: T[], size: number): T[][] {
-  const result: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    result.push(arr.slice(i, i + size));
-  }
-  return result;
-}
-
-const posts: Post[] = await getCollection('posts');
-posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
-const groupedItems = chunkArray(posts, 5);
 ---
 
-<Layout>
+<Layout title="All Posts · Survive the AI">
   <main class="bg-white py-20 text-neutral-900">
-    <div class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
-      <div class="mb-10 space-y-3">
-        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Blog</p>
-        <h1 class="text-3xl font-extrabold text-neutral-900 sm:text-4xl">Latest posts</h1>
-        <p class="text-neutral-600">Newest to oldest, refreshed automatically from the posts collection.</p>
-      </div>
-      <PostGrid groupedItems={groupedItems} />
+    <div class="mx-auto max-w-screen-md space-y-4 px-4 sm:px-6 lg:px-8 text-center">
+      <meta http-equiv="refresh" content="0; url=/posts/" />
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Redirecting</p>
+      <h1 class="text-3xl font-extrabold text-neutral-900 sm:text-4xl">We moved the blog</h1>
+      <p class="text-neutral-600">
+        All posts now live at <a class="text-blue-600 underline" href="/posts/">/posts</a>. You should be redirected automatically.
+      </p>
     </div>
   </main>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,38 +1,148 @@
 ---
 import Layout from '../layouts/BaseLayout.astro';
-import PostGrid from '../components/PostGrid.astro';
-import TopicPreview from '../components/TopicPreview.astro';
-import NewsletterSignup from '../components/NewsletterSignup.astro';
 import { getCollection } from 'astro:content';
-import type { Post } from '../data/Posts';
+import BlogList from '../components/BlogList.astro';
+import { buildSections, paginatePosts } from '../utils/postSections';
+import { formatDate } from '../utils/format';
 
-function chunkArray<T>(arr: T[], size: number): T[][] {
-  const result: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    result.push(arr.slice(i, i + size));
-  }
-  return result;
-}
-
-const chunkSize = 5;
-
-const posts: Post[] = await getCollection('posts');
-posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
-const groupedItems = chunkArray(posts, chunkSize);
+const posts = await getCollection('posts');
+const { featured, evergreen, latest, remaining } = buildSections(posts);
+const { pages: remainingPages, totalPages } = paginatePosts(remaining, 6);
+const allPostsFirstPage = remainingPages[0] ?? [];
 ---
 
-<Layout>
-  <main class="bg-white py-20 text-neutral-900">
-    <div class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
-      <div class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div>
-          <PostGrid groupedItems={groupedItems} />
-        </div>
-        <aside class="space-y-6">
-          <TopicPreview />
-          <NewsletterSignup />
-        </aside>
-      </div>
+<Layout title="Survive the AI — Prepare, adapt, and stay ahead">
+  <main class="bg-white py-14 text-neutral-900 sm:py-16">
+    <div class="mx-auto max-w-screen-xl space-y-14 px-4 sm:px-6 lg:px-8">
+      {featured ? (
+        <section class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] lg:items-center" data-testid="hero-section">
+          <div class="space-y-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Featured</p>
+            <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl lg:text-5xl">
+              {featured.data.title}
+            </h1>
+            <p class="max-w-3xl text-lg text-neutral-700 sm:text-xl">{featured.data.description}</p>
+            <div class="flex flex-wrap items-center gap-3 text-sm text-neutral-600">
+              <span>{formatDate(featured.data.date)}</span>
+              <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+              <span>Impact Score {featured.data.impact_score}</span>
+            </div>
+            <div class="flex flex-wrap gap-3 pt-2">
+              <a
+                href={`/posts/${featured.slug}/`}
+                class="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+              >
+                Read the feature
+              </a>
+              <a
+                href="/posts"
+                class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-6 py-3 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+              >
+                Browse all posts
+              </a>
+            </div>
+          </div>
+          <a href={`/posts/${featured.slug}/`} class="block overflow-hidden rounded-3xl shadow-lg ring-1 ring-neutral-200 transition hover:-translate-y-0.5 hover:shadow-xl">
+            <img
+              src={featured.data.heroImage}
+              alt={featured.data.heroImageAlt ?? featured.data.title}
+              class="h-full w-full object-cover"
+              loading="lazy"
+              decoding="async"
+              width="1200"
+              height="630"
+            />
+          </a>
+        </section>
+      ) : (
+        <section class="space-y-3" data-testid="hero-section">
+          <h1 class="text-3xl font-extrabold sm:text-4xl">No posts published yet.</h1>
+          <p class="text-neutral-600">Come back soon for the latest analysis on surviving the AI disruption.</p>
+        </section>
+      )}
+
+      {evergreen.length > 0 && (
+        <section class="space-y-4" data-testid="evergreen-section">
+          <div class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Evergreen</p>
+            <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Playbooks that stay relevant</h2>
+          </div>
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {evergreen.map((post) => (
+              <a
+                href={`/posts/${post.slug}/`}
+                class="flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300"
+              >
+                <img
+                  src={post.data.heroImageThumb ?? post.data.heroImage}
+                  alt={post.data.heroImageAlt ?? post.data.title}
+                  class="h-44 w-full object-cover"
+                  loading="lazy"
+                  decoding="async"
+                  width="640"
+                  height="360"
+                />
+                <div class="flex flex-1 flex-col gap-2 p-4">
+                  <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
+                    <span>Impact {post.data.impact_score}</span>
+                    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+                    <span>{formatDate(post.data.date)}</span>
+                  </div>
+                  <h3 class="text-base font-semibold text-neutral-900">{post.data.title}</h3>
+                  <p class="text-sm text-neutral-700">{post.data.description}</p>
+                </div>
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {latest.length > 0 && (
+        <section class="space-y-4" data-testid="latest-section">
+          <div class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Latest</p>
+            <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Fresh drops</h2>
+          </div>
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {latest.map((post) => (
+              <a
+                href={`/posts/${post.slug}/`}
+                class="flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300"
+              >
+                <img
+                  src={post.data.heroImageThumb ?? post.data.heroImage}
+                  alt={post.data.heroImageAlt ?? post.data.title}
+                  class="h-44 w-full object-cover"
+                  loading="lazy"
+                  decoding="async"
+                  width="640"
+                  height="360"
+                />
+                <div class="flex flex-1 flex-col gap-2 p-4">
+                  <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
+                    <span>Impact {post.data.impact_score}</span>
+                    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+                    <span>{formatDate(post.data.date)}</span>
+                  </div>
+                  <h3 class="text-base font-semibold text-neutral-900">{post.data.title}</h3>
+                  <p class="text-sm text-neutral-700">{post.data.description}</p>
+                </div>
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {allPostsFirstPage.length > 0 && (
+        <section class="space-y-6" id="all-posts" data-testid="all-posts-section">
+          <div class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">All Posts</p>
+            <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Everything else</h2>
+            <p class="text-neutral-600">Browse the full archive. Pagination links take you to the dedicated posts index.</p>
+          </div>
+          <BlogList posts={allPostsFirstPage} currentPage={1} totalPages={totalPages} basePath="/posts" />
+        </section>
+      )}
     </div>
   </main>
 </Layout>

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -4,7 +4,7 @@ import PostLayout from '../../layouts/PostLayout.astro';
 import { readingTime } from '../../utils/readingTime';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('posts');
+  const posts = (await getCollection('posts')).filter((post) => !post.data.draft);
   return posts.map((post) => ({
     params: { slug: post.slug },
     props: { post, allPosts: posts },

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -1,0 +1,26 @@
+---
+import Layout from '../../layouts/BaseLayout.astro';
+import BlogList from '../../components/BlogList.astro';
+import { getCollection } from 'astro:content';
+import { sortPosts } from '../../utils/postSections';
+
+const pageSize = 6;
+const posts = sortPosts(await getCollection('posts')).filter((post) => !post.data.draft);
+const totalPages = Math.max(1, Math.ceil(posts.length / pageSize));
+const pagePosts = posts.slice(0, pageSize);
+const pageTitle = 'All Posts';
+---
+
+<Layout title={`${pageTitle} · Survive the AI`} description="Browse every SurviveTheAI post in reverse chronological order.">
+  <main class="bg-white py-14 text-neutral-900 sm:py-16">
+    <div class="mx-auto max-w-screen-xl space-y-6 px-4 sm:px-6 lg:px-8">
+      <div class="space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Archive</p>
+        <h1 class="text-3xl font-extrabold text-neutral-900 sm:text-4xl">{pageTitle}</h1>
+        <p class="text-neutral-600">Newest first, six posts per page.</p>
+      </div>
+
+      <BlogList posts={pagePosts} currentPage={1} totalPages={totalPages} basePath="/posts" />
+    </div>
+  </main>
+</Layout>

--- a/src/pages/posts/page/[page].astro
+++ b/src/pages/posts/page/[page].astro
@@ -1,0 +1,47 @@
+---
+import Layout from '../../../layouts/BaseLayout.astro';
+import BlogList from '../../../components/BlogList.astro';
+import { getCollection } from 'astro:content';
+import { sortPosts } from '../../../utils/postSections';
+import type { PostEntry } from '../../../content/config';
+
+export async function getStaticPaths() {
+  const PAGE_SIZE = 6;
+  const posts = sortPosts(await getCollection('posts')).filter((post) => !post.data.draft);
+  const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
+
+  return Array.from({ length: Math.max(0, totalPages - 1) }, (_, index) => {
+    const pageNumber = index + 2;
+    const start = (pageNumber - 1) * PAGE_SIZE;
+    const pagePosts = posts.slice(start, start + PAGE_SIZE);
+
+    return {
+      params: { page: pageNumber.toString() },
+      props: { pageNumber, totalPages, pagePosts },
+      route: `/posts/page/${pageNumber}/`,
+    };
+  });
+}
+
+const { pageNumber, totalPages, pagePosts } = Astro.props as {
+  pageNumber: number;
+  totalPages: number;
+  pagePosts: PostEntry[];
+};
+
+const pageTitle = `All Posts – Page ${pageNumber}`;
+---
+
+<Layout title={`${pageTitle} · Survive the AI`} description="SurviveTheAI post archive with pagination.">
+  <main class="bg-white py-14 text-neutral-900 sm:py-16">
+    <div class="mx-auto max-w-screen-xl space-y-6 px-4 sm:px-6 lg:px-8">
+      <div class="space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Archive</p>
+        <h1 class="text-3xl font-extrabold text-neutral-900 sm:text-4xl">{pageTitle}</h1>
+        <p class="text-neutral-600">Newest first, six posts per page.</p>
+      </div>
+
+      <BlogList posts={pagePosts} currentPage={pageNumber} totalPages={totalPages} basePath="/posts" />
+    </div>
+  </main>
+</Layout>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,43 @@
+import { getCollection } from 'astro:content';
+import { sortPosts } from '../utils/postSections';
+
+export const prerender = true;
+
+const PAGE_SIZE = 6;
+
+export async function GET({ site }: { site: URL | undefined }) {
+  const base = (site ?? new URL('https://survivetheai.com')).toString().replace(/\/$/, '');
+  const posts = sortPosts(await getCollection('posts')).filter((post) => !post.data.draft);
+  const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
+
+  const urls: string[] = [];
+  const staticPaths = ['/', '/posts/', '/drops/', '/quiz/', '/blog/'];
+  for (const path of staticPaths) {
+    urls.push(renderUrl(base, path));
+  }
+
+  for (let page = 2; page <= totalPages; page += 1) {
+    urls.push(renderUrl(base, `/posts/page/${page}/`));
+  }
+
+  for (const post of posts) {
+    urls.push(renderUrl(base, `/posts/${post.slug}/`, post.data.date));
+  }
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>`;
+
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}
+
+function renderUrl(base: string, path: string, lastmod?: Date) {
+  const url = new URL(path, base).toString();
+  return `<url><loc>${url}</loc>${lastmod ? `<lastmod>${lastmod.toISOString()}` : ''}${lastmod ? '</lastmod>' : ''}</url>`;
+}

--- a/src/utils/postSections.ts
+++ b/src/utils/postSections.ts
@@ -1,0 +1,67 @@
+import type { PostEntry } from '../content/config';
+
+type Sections = {
+  featured?: PostEntry;
+  evergreen: PostEntry[];
+  latest: PostEntry[];
+  remaining: PostEntry[];
+};
+
+export function sortPosts(posts: PostEntry[]): PostEntry[] {
+  return [...posts].sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+}
+
+export function buildSections(allPosts: PostEntry[]): Sections {
+  const posts = sortPosts(allPosts).filter((post) => !post.data.draft);
+  const used = new Set<string>();
+
+  let featured = posts.find((post) => post.data.featured);
+  if (!featured && posts.length > 0) {
+    featured = posts[0];
+  }
+  if (featured) {
+    used.add(featured.slug);
+  }
+
+  const evergreen: PostEntry[] = [];
+  for (const post of posts) {
+    if (used.has(post.slug)) continue;
+    if (post.data.evergreen) {
+      evergreen.push(post);
+      used.add(post.slug);
+    }
+    if (evergreen.length === 4) break;
+  }
+
+  if (evergreen.length < 4) {
+    for (const post of posts) {
+      if (used.has(post.slug)) continue;
+      evergreen.push(post);
+      used.add(post.slug);
+      if (evergreen.length === 4) break;
+    }
+  }
+
+  const latest: PostEntry[] = [];
+  for (const post of posts) {
+    if (used.has(post.slug)) continue;
+    latest.push(post);
+    used.add(post.slug);
+    if (latest.length === 6) break;
+  }
+
+  const remaining = posts.filter((post) => !used.has(post.slug));
+
+  return { featured, evergreen, latest, remaining };
+}
+
+export function paginatePosts(posts: PostEntry[], pageSize: number) {
+  const sorted = sortPosts(posts).filter((post) => !post.data.draft);
+  const pages: PostEntry[][] = [];
+
+  for (let i = 0; i < sorted.length; i += pageSize) {
+    pages.push(sorted.slice(i, i + pageSize));
+  }
+
+  return { pages, totalPages: pages.length || 1 };
+}

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Homepage layout', () => {
+  test('shows hero, evergreen, latest, and all posts without duplicate slugs', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByTestId('hero-section')).toBeVisible();
+    await expect(page.getByTestId('evergreen-section')).toBeVisible();
+    await expect(page.getByTestId('latest-section')).toBeVisible();
+    await expect(page.getByTestId('all-posts-section')).toBeVisible();
+
+    const slugs = await page.locator('[data-testid$="-section"] a[href^="/posts/"]').evaluateAll((links) =>
+      links
+        .map((link) => (link.getAttribute('href') ?? '').replace(/\/posts\/|\/$/g, ''))
+        .filter(Boolean),
+    );
+
+    const unique = new Set(slugs);
+    expect(unique.size).toBe(slugs.length);
+  });
+
+  test('hides newsletter and version switchers', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('input[type="email"], form[action*="newsletter"]')).toHaveCount(0);
+    expect(await page.getByText(/version/i).count()).toBe(0);
+  });
+
+  test('mobile layout stays stacked without horizontal scroll', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const innerWidth = await page.evaluate(() => window.innerWidth);
+
+    expect(scrollWidth).toBeLessThanOrEqual(innerWidth + 2);
+
+    await page.getByTestId('mobile-menu-toggle').click();
+    await expect(page.getByTestId('mobile-menu')).toBeVisible();
+  });
+});

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('desktop navigation routes to posts', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'All Posts' }).click();
+  await expect(page).toHaveURL(/\/posts\/$/);
+});
+
+test('mobile navigation toggles and routes', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  await page.getByTestId('mobile-menu-toggle').click();
+  const allPostsLink = page.getByRole('link', { name: 'All Posts' });
+  await expect(allPostsLink).toBeVisible();
+  await allPostsLink.click();
+
+  await expect(page).toHaveURL(/\/posts\/$/);
+});

--- a/tests/posts.spec.ts
+++ b/tests/posts.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+test('posts index paginates six posts per page', async ({ page }) => {
+  await page.goto('/posts/');
+  await expect(page).toHaveTitle(/All Posts/);
+
+  await expect(page.locator('[data-testid="blog-list"] article')).toHaveCount(6);
+  await expect(page.getByTestId('pagination')).toBeVisible();
+
+  await page.getByRole('link', { name: '2' }).click();
+  await expect(page).toHaveURL(/\/posts\/page\/2\//);
+  await expect(page.locator('[data-testid="blog-list"] article')).toHaveCount(6);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText(/All Posts – Page 2/);
+});
+
+test('individual post pages render without signup forms', async ({ page }) => {
+  await page.goto('/posts/');
+  const firstPostLink = page.locator('[data-testid="blog-list"] article a[href^="/posts/"]').first();
+  const href = await firstPostLink.getAttribute('href');
+  expect(href).not.toBeNull();
+
+  await page.goto(href!);
+  await expect(page.locator('article')).toBeVisible();
+  await expect(page.locator('input[type="email"], form[action*="newsletter"]')).toHaveCount(0);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
       "@data/*": ["src/data/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "tests", "playwright.config.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### Motivation
- Prepare the site for MVP by finalizing the homepage into deterministic sections (featured, evergreen, latest, all-posts) and hide newsletter CTAs to avoid premature signups.
- Avoid layout breakage and duplication by auto-tagging and de-duplicating posts across homepage sections.
- Simplify navigation and routing so all content lives under `/posts` and remove version/signup UI from header/footer.
- Restore end-to-end coverage with Playwright tests to validate layout, routing, and pagination for the MVP.

### Description
- Implemented post selection utilities in `src/utils/postSections.ts` with `sortPosts`, `buildSections` (auto-feature/evergreen fallback) and `paginatePosts`, using a `Set<string>` to prevent duplicate slugs across sections.
- Updated content schema in `src/content/config.ts` to add `draft`, `featured`, `evergreen`, and `heroImageThumb`, and filtered drafts in page generators and `getStaticPaths`.
- Reworked the homepage `src/pages/index.astro` to render `Featured` → `Evergreen` → `Latest` → `All Posts` (paginated first page) and removed `NewsletterSignup` usages, plus added `BlogList` component at `src/components/BlogList.astro` and dedicated posts index and paginated pages under `src/pages/posts/`.
- Cleaned navigation and footer in `src/components/Navbar.astro` and `src/components/Footer.astro` (removed quiz/signup/version switcher, added `All Posts` and logo routing to `/`), added `sitemap` at `src/pages/sitemap.xml.ts`, updated `BaseLayout.astro` for dynamic titles, and added `tsconfig` and `package.json` entries plus `playwright.config.ts` and Playwright tests under `tests/`.

### Testing
- Ran a production build with `npm run build` / `astro build`, which completed successfully and generated the site's static pages (build output completed without errors).
- Attempted to run the test runner with `npm test` (which runs `playwright test`), but the command failed because `@playwright/test` could not be installed in this environment due to network/registry restrictions; the Playwright test files are present and ready to run once dependencies are available.
- Static preview was exercised locally during development and the site renders the new sections and paginated routes as expected in the build output. 
- Added Playwright configuration (`playwright.config.ts`) and test specs (`tests/*.spec.ts`) covering homepage sections, navigation (desktop/mobile), post routing, and pagination, which will run when `@playwright/test` is installed and `npm test` is executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c765a54d08326b4708c128deef0f1)