### PR TITLE
Finalize Survival Library nav, filtering, categories, and tests

### DIFF
--- a/src/components/BlogList.astro
+++ b/src/components/BlogList.astro
@@ -15,7 +15,7 @@ const normalizedBasePath = basePath.endsWith('/') ? basePath.slice(0, -1) : base
 const buildPageHref = (page: number) => (page === 1 ? `${normalizedBasePath}/` : `${normalizedBasePath}/page/${page}/`);
 ---
 
-<div class="space-y-8" data-testid="blog-list">
+<div class="space-y-8" data-testid="blog-list" data-total-pages={totalPages} data-current-page={currentPage}>
   <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
     {posts.map((post) => {
       const primaryCategory = post.data.topics?.[0] ? categoryByKey.get(post.data.topics[0]) : undefined;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@
     <div class="text-gray-700 font-semibold">© Survive the AI</div>
     <nav class="flex flex-wrap gap-4 text-gray-500 font-medium">
       <a href="/" class="hover:text-blue-600 transition">Home</a>
-      <a href="/posts" class="hover:text-blue-600 transition">All Posts</a>
+      <a href="/posts" class="hover:text-blue-600 transition">Survival Library</a>
       <a href="/privacy" class="hover:text-blue-600 transition">Privacy</a>
       <a href="/terms" class="hover:text-blue-600 transition">Terms</a>
     </nav>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,30 +1,73 @@
 ---
+import { TOPIC_CATEGORIES } from '../data/categories';
+
 const links = [
-  { href: '/', label: 'Home' },
-  { href: '/posts', label: 'All Posts' },
-  { href: '/drops', label: 'Drops' },
+  { href: '/', label: 'Home', testId: 'nav-home' },
+  { href: '/posts', label: 'Survival Library', testId: 'nav-library' },
 ];
+
+const survivalAreas = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
 ---
-<nav class="bg-zinc-900 text-white" data-testid="navbar">
+<nav class="bg-neutral-950 text-neutral-50 shadow-sm" data-testid="navbar">
   <div class="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4">
-    <a href="/" class="flex items-center gap-2 text-2xl font-bold tracking-tight hover:text-orange-200 transition">
+    <a href="/" class="flex items-center gap-2 text-2xl font-bold tracking-tight text-white transition hover:text-neutral-50" data-testid="nav-logo">
       Survive the AI
     </a>
     <div class="hidden items-center gap-2 md:flex">
       {links.map((link) => (
         <a
           href={link.href}
-          class="rounded-full px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+          class="rounded-full px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          data-testid={link.testId}
         >
           {link.label}
         </a>
       ))}
+      <div class="relative" data-testid="survival-areas-desktop">
+        <button
+          type="button"
+          class="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-controls="desktop-survival-areas"
+          data-dropdown-trigger
+          data-target="desktop-survival-areas"
+        >
+          Survival Areas
+          <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path
+              fill-rule="evenodd"
+              d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.17l3.71-3.94a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+        <div
+          id="desktop-survival-areas"
+          role="menu"
+          data-dropdown-menu
+          data-open="false"
+          class="absolute right-0 z-20 mt-3 hidden min-w-[240px] rounded-2xl bg-neutral-900/95 p-2 shadow-2xl ring-1 ring-white/15 backdrop-blur data-[open=true]:flex data-[open=true]:flex-col"
+        >
+          {survivalAreas.map((area) => (
+            <a
+              href={`/category/${area.key}/`}
+              role="menuitem"
+              class="rounded-xl px-4 py-3 text-sm font-semibold text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+              data-testid={`survival-area-${area.key}`}
+            >
+              {area.label}
+            </a>
+          ))}
+        </div>
+      </div>
     </div>
     <button
       type="button"
-      class="inline-flex items-center justify-center rounded-full p-2 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 md:hidden"
+      class="inline-flex items-center justify-center rounded-full p-2 text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 md:hidden"
       aria-label="Toggle navigation menu"
       aria-expanded="false"
+      aria-controls="mobile-menu"
       data-menu-toggle
       data-testid="mobile-menu-toggle"
     >
@@ -33,27 +76,135 @@ const links = [
       </svg>
     </button>
   </div>
-  <div id="mobile-menu" class="hidden border-t border-white/10 bg-zinc-900 md:hidden" data-testid="mobile-menu">
+  <div id="mobile-menu" class="hidden border-t border-white/10 bg-neutral-900 md:hidden" data-testid="mobile-menu">
     <div class="mx-auto flex max-w-7xl flex-col gap-2 px-4 py-4">
       {links.map((link) => (
         <a
           href={link.href}
-          class="rounded-xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+          class="rounded-xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          data-testid={`${link.testId}-mobile`}
         >
           {link.label}
         </a>
       ))}
+      <div class="border-t border-white/10 pt-3" data-testid="survival-areas-mobile">
+        <button
+          type="button"
+          class="flex w-full items-center justify-between rounded-xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-controls="mobile-survival-areas"
+          data-dropdown-trigger
+          data-target="mobile-survival-areas"
+        >
+          Survival Areas
+          <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path
+              fill-rule="evenodd"
+              d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.17l3.71-3.94a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+        <div
+          id="mobile-survival-areas"
+          role="menu"
+          data-dropdown-menu
+          data-open="false"
+          class="mt-2 hidden flex-col gap-2 rounded-xl bg-neutral-900/60 p-2 ring-1 ring-white/10 data-[open=true]:flex"
+        >
+          {survivalAreas.map((area) => (
+            <a
+              href={`/category/${area.key}/`}
+              role="menuitem"
+              class="rounded-lg px-4 py-3 text-sm font-semibold text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+              data-testid={`survival-area-${area.key}-mobile`}
+            >
+              {area.label}
+            </a>
+          ))}
+        </div>
+      </div>
     </div>
   </div>
 </nav>
 <script is:inline>
   const toggle = document.querySelector('[data-menu-toggle]');
   const mobileMenu = document.getElementById('mobile-menu');
+  const dropdownTriggers = Array.from(document.querySelectorAll('[data-dropdown-trigger]'));
+
+  const closeDropdown = (menu, trigger) => {
+    if (!menu) return;
+    menu.dataset.open = 'false';
+    if (trigger) trigger.setAttribute('aria-expanded', 'false');
+  };
+
+  const closeAllDropdowns = (exceptMenu) => {
+    dropdownTriggers.forEach((trigger) => {
+      const targetId = trigger.getAttribute('data-target');
+      const menu = targetId ? document.getElementById(targetId) : null;
+      if (menu && menu !== exceptMenu) {
+        closeDropdown(menu, trigger);
+      }
+    });
+  };
+
+  dropdownTriggers.forEach((trigger) => {
+    const targetId = trigger.getAttribute('data-target');
+    const menu = targetId ? document.getElementById(targetId) : null;
+    if (!menu) return;
+
+    trigger.addEventListener('click', (event) => {
+      event.preventDefault();
+      const isOpen = menu.dataset.open === 'true';
+      closeAllDropdowns(isOpen ? null : menu);
+      menu.dataset.open = (!isOpen).toString();
+      trigger.setAttribute('aria-expanded', (!isOpen).toString());
+      if (!isOpen) {
+        const firstLink = menu.querySelector('a');
+        if (firstLink) firstLink.focus();
+      }
+    });
+
+    trigger.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        trigger.click();
+      }
+      if (event.key === 'Escape') {
+        closeDropdown(menu, trigger);
+        trigger.focus();
+      }
+    });
+
+    menu.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeDropdown(menu, trigger);
+        trigger.focus();
+      }
+    });
+  });
+
+  document.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const isInsideDropdown = dropdownTriggers.some((trigger) => {
+      const targetId = trigger.getAttribute('data-target');
+      const menu = targetId ? document.getElementById(targetId) : null;
+      return (trigger && trigger.contains(target)) || (menu && menu.contains(target));
+    });
+    if (!isInsideDropdown) {
+      closeAllDropdowns(null);
+    }
+  });
 
   if (toggle && mobileMenu) {
     toggle.addEventListener('click', () => {
       const isHidden = mobileMenu.classList.toggle('hidden');
       toggle.setAttribute('aria-expanded', (!isHidden).toString());
+      if (isHidden) {
+        closeAllDropdowns(null);
+      }
     });
   }
 </script>

--- a/src/content/posts/AI Is Leaving the Cloud.md
+++ b/src/content/posts/AI Is Leaving the Cloud.md
@@ -3,6 +3,7 @@ title: "AI Is Leaving the Cloud - And That's Why Job Loss Is About to Accelerate
 description: "Local, open-weight AI removes friction, making automation cheap, private, and uncontrollable, silently eroding roles long before layoffs are announced."
 date: 2025-12-18
 author: "Lee Cuevas"
+featured: true
 category: "Work & Money - AI Job Displacement"
 topics:
   - "work-money"
@@ -255,7 +256,6 @@ Fear, in this case, is not irrational.
 It is information.
 
 And those who recognize what is happening early still have time to adapt.
-
 
 
 

--- a/src/content/posts/Replacing Human Intimacy.md
+++ b/src/content/posts/Replacing Human Intimacy.md
@@ -3,6 +3,7 @@ title: "The Artificial Embrace: How AI Companions Are Quietly Replacing Human In
 description: "AI companions promise endless empathy and attention -- this post explores how they reshape intimacy, fuel dependence, and deepen loneliness."
 date: 2025-12-05
 author: "Admin"
+evergreen: true
 category: "Love, Sex & Connection - AI Relationships & Synthetic Intimacy"
 topics:
   - "love-connection"
@@ -97,5 +98,4 @@ That’s what makes it addictive. And that’s exactly what makes it dangerous.
 In the next installment, we’ll pull back the veil on Silicon Valley’s growing influence over emotional AI—and explore what happens when therapeutic tools become **addictive products** by design.
 
 ---
-
 

--- a/src/content/posts/ai-study-platforms-2025.md
+++ b/src/content/posts/ai-study-platforms-2025.md
@@ -3,6 +3,7 @@ title: "Don’t Get Replaced: Pick the AI Study Platform That Builds the Right S
 description: "Match your skill gaps to the right AI study tool—so you stay useful and employed."
 date: 2025-11-07T12:00:00Z
 author: "Lee Cuevas"
+evergreen: true
 category: "Kids & School – AI vs Your Children’s Future"
 topics:
   - "kids-school"
@@ -222,5 +223,4 @@ If not, change tools or change your stack.
 ---
 
 *SurviveTheAI — practical guidance to stay useful in an AI world.*
-
 

--- a/src/content/posts/aiproofyourkid.md
+++ b/src/content/posts/aiproofyourkid.md
@@ -3,6 +3,7 @@ title: "How to AI-Proof Your Kid"
 description: "A practical guide for parents who want to prepare their children for a world dominated by artificial intelligence."
 date: 2025-07-29T18:52:00Z
 author: "Justin Cuevas"
+evergreen: true
 category: "Kids & School – AI vs Your Children’s Future"
 topics:
   - "kids-school"
@@ -54,5 +55,4 @@ AI will speed up everything — except human biology. Resilience, mindfulness, a
 AI isn’t the enemy. But passivity is. Help your kid **be the human the machines can’t replace** — adaptable, ethical, creative, and emotionally intelligent.
 
 Their future depends on it.
-
 

--- a/src/content/posts/soft-extinction.md
+++ b/src/content/posts/soft-extinction.md
@@ -3,6 +3,7 @@ title: "Placeholder: Soft Extinction"
 description: "This is a placeholder post for the Soft Extinction category."
 date: 2025-07-31
 author: "Admin"
+evergreen: true
 category: "System Shock – Soft Extinction & Collapse"
 topics:
   - "system-shock"
@@ -18,4 +19,3 @@ canonicalUrl: "https://survivetheai.com/posts/soft-extinction"
 ---
 
 Content coming soon for this category.
-

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -2,14 +2,15 @@
 import Layout from '../layouts/BaseLayout.astro';
 ---
 
-<Layout title="All Posts · Survive the AI">
+<Layout title="Survival Library · Survive the AI">
   <main class="bg-white py-20 text-neutral-900">
     <div class="mx-auto max-w-screen-md space-y-4 px-4 sm:px-6 lg:px-8 text-center">
       <meta http-equiv="refresh" content="0; url=/posts/" />
       <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Redirecting</p>
       <h1 class="text-3xl font-extrabold text-neutral-900 sm:text-4xl">We moved the blog</h1>
       <p class="text-neutral-600">
-        All posts now live at <a class="text-blue-600 underline" href="/posts/">/posts</a>. You should be redirected automatically.
+        Everything now lives inside the Survival Library at <a class="text-blue-600 underline" href="/posts/">/posts</a>. You should be
+        redirected automatically.
       </p>
     </div>
   </main>

--- a/src/pages/category/[key].astro
+++ b/src/pages/category/[key].astro
@@ -1,0 +1,43 @@
+---
+import Layout from '../../layouts/BaseLayout.astro';
+import BlogList from '../../components/BlogList.astro';
+import { getCollection } from 'astro:content';
+import { TOPIC_CATEGORIES } from '../../data/categories';
+import { sortPosts } from '../../utils/postSections';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('posts');
+  const published = posts.filter((post) => !post.data.draft);
+
+  return TOPIC_CATEGORIES.map((category) => {
+    const categoryPosts = sortPosts(published.filter((post) => post.data.topics?.includes(category.key)));
+    return {
+      params: { key: category.key },
+      props: { category, categoryPosts },
+      route: `/category/${category.key}/`,
+    };
+  });
+}
+
+const { category, categoryPosts } = Astro.props;
+const pageTitle = `${category.label} · Survival Areas`;
+---
+<Layout title={`${pageTitle} · Survive the AI`} description={`Survival posts focused on ${category.label}.`}>
+  <main class="bg-white py-14 text-neutral-900 sm:py-16">
+    <div class="mx-auto max-w-screen-xl space-y-6 px-4 sm:px-6 lg:px-8" data-testid="category-page">
+      <div class="space-y-3">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Survival Areas</p>
+        <h1 class="text-3xl font-extrabold text-neutral-900 sm:text-4xl">{category.label}</h1>
+        {category.description && <p class="max-w-3xl text-neutral-600">{category.description}</p>}
+      </div>
+
+      {categoryPosts.length > 0 ? (
+        <BlogList posts={categoryPosts} currentPage={1} totalPages={1} basePath={`/category/${category.key}`} />
+      ) : (
+        <div class="rounded-2xl border border-neutral-200 bg-neutral-50 p-6 text-neutral-700">
+          No posts found in this Survival Area yet. Check back soon.
+        </div>
+      )}
+    </div>
+  </main>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,14 +1,11 @@
 ---
 import Layout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import BlogList from '../components/BlogList.astro';
-import { buildSections, paginatePosts } from '../utils/postSections';
+import { buildSections } from '../utils/postSections';
 import { formatDate } from '../utils/format';
 
 const posts = await getCollection('posts');
 const { featured, evergreen, latest, remaining } = buildSections(posts);
-const { pages: remainingPages, totalPages } = paginatePosts(remaining, 6);
-const allPostsFirstPage = remainingPages[0] ?? [];
 ---
 
 <Layout title="Survive the AI — Prepare, adapt, and stay ahead">
@@ -38,7 +35,7 @@ const allPostsFirstPage = remainingPages[0] ?? [];
                 href="/posts"
                 class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-6 py-3 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
               >
-                Browse all posts
+                Browse the Survival Library
               </a>
             </div>
           </div>
@@ -101,7 +98,7 @@ const allPostsFirstPage = remainingPages[0] ?? [];
         <section class="space-y-4" data-testid="latest-section">
           <div class="space-y-2">
             <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Latest</p>
-            <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Fresh drops</h2>
+            <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Latest intelligence</h2>
           </div>
           <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {latest.map((post) => (
@@ -133,14 +130,30 @@ const allPostsFirstPage = remainingPages[0] ?? [];
         </section>
       )}
 
-      {allPostsFirstPage.length > 0 && (
-        <section class="space-y-6" id="all-posts" data-testid="all-posts-section">
+      {remaining.length > 0 && (
+        <section class="space-y-6" data-testid="library-cta-section">
           <div class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">All Posts</p>
-            <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Everything else</h2>
-            <p class="text-neutral-600">Browse the full archive. Pagination links take you to the dedicated posts index.</p>
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Survival Library</p>
+            <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Rolled off? It lives in the library.</h2>
+            <p class="text-neutral-600">
+              We keep featured, evergreen, and the latest five posts up top. Everything else moves to the Survival Library so you can binge
+              without duplicates.
+            </p>
           </div>
-          <BlogList posts={allPostsFirstPage} currentPage={1} totalPages={totalPages} basePath="/posts" />
+          <div class="flex flex-wrap gap-3">
+            <a
+              href="/posts"
+              class="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+            >
+              Go to the Survival Library
+            </a>
+            <a
+              href="/category/work-money"
+              class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-6 py-3 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+            >
+              Browse Survival Areas
+            </a>
+          </div>
         </section>
       )}
     </div>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -2,13 +2,14 @@
 import Layout from '../../layouts/BaseLayout.astro';
 import BlogList from '../../components/BlogList.astro';
 import { getCollection } from 'astro:content';
-import { sortPosts } from '../../utils/postSections';
+import { buildSections, sortPosts, SURVIVAL_LIBRARY_PAGE_SIZE } from '../../utils/postSections';
 
-const pageSize = 6;
-const posts = sortPosts(await getCollection('posts')).filter((post) => !post.data.draft);
-const totalPages = Math.max(1, Math.ceil(posts.length / pageSize));
-const pagePosts = posts.slice(0, pageSize);
-const pageTitle = 'All Posts';
+const posts = await getCollection('posts');
+const { remaining } = buildSections(posts);
+const sortedLibraryPosts = sortPosts(remaining);
+const totalPages = Math.max(1, Math.ceil(sortedLibraryPosts.length / SURVIVAL_LIBRARY_PAGE_SIZE));
+const pagePosts = sortedLibraryPosts.slice(0, SURVIVAL_LIBRARY_PAGE_SIZE);
+const pageTitle = 'Survival Library';
 ---
 
 <Layout title={`${pageTitle} · Survive the AI`} description="Browse every SurviveTheAI post in reverse chronological order.">
@@ -17,7 +18,9 @@ const pageTitle = 'All Posts';
       <div class="space-y-2">
         <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Archive</p>
         <h1 class="text-3xl font-extrabold text-neutral-900 sm:text-4xl">{pageTitle}</h1>
-        <p class="text-neutral-600">Newest first, six posts per page.</p>
+        <p class="text-neutral-600">
+          Excludes the featured post, evergreen playbooks, and the five freshest stories to keep the homepage clean. Twelve posts per page.
+        </p>
       </div>
 
       <BlogList posts={pagePosts} currentPage={1} totalPages={totalPages} basePath="/posts" />

--- a/src/pages/posts/page/[page].astro
+++ b/src/pages/posts/page/[page].astro
@@ -2,18 +2,19 @@
 import Layout from '../../../layouts/BaseLayout.astro';
 import BlogList from '../../../components/BlogList.astro';
 import { getCollection } from 'astro:content';
-import { sortPosts } from '../../../utils/postSections';
+import { buildSections, sortPosts, SURVIVAL_LIBRARY_PAGE_SIZE } from '../../../utils/postSections';
 import type { PostEntry } from '../../../content/config';
 
 export async function getStaticPaths() {
-  const PAGE_SIZE = 6;
-  const posts = sortPosts(await getCollection('posts')).filter((post) => !post.data.draft);
-  const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
+  const posts = await getCollection('posts');
+  const { remaining } = buildSections(posts);
+  const sortedLibraryPosts = sortPosts(remaining);
+  const totalPages = Math.max(1, Math.ceil(sortedLibraryPosts.length / SURVIVAL_LIBRARY_PAGE_SIZE));
 
   return Array.from({ length: Math.max(0, totalPages - 1) }, (_, index) => {
     const pageNumber = index + 2;
-    const start = (pageNumber - 1) * PAGE_SIZE;
-    const pagePosts = posts.slice(start, start + PAGE_SIZE);
+    const start = (pageNumber - 1) * SURVIVAL_LIBRARY_PAGE_SIZE;
+    const pagePosts = sortedLibraryPosts.slice(start, start + SURVIVAL_LIBRARY_PAGE_SIZE);
 
     return {
       params: { page: pageNumber.toString() },
@@ -29,7 +30,7 @@ const { pageNumber, totalPages, pagePosts } = Astro.props as {
   pagePosts: PostEntry[];
 };
 
-const pageTitle = `All Posts – Page ${pageNumber}`;
+const pageTitle = `Survival Library – Page ${pageNumber}`;
 ---
 
 <Layout title={`${pageTitle} · Survive the AI`} description="SurviveTheAI post archive with pagination.">
@@ -38,7 +39,9 @@ const pageTitle = `All Posts – Page ${pageNumber}`;
       <div class="space-y-2">
         <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Archive</p>
         <h1 class="text-3xl font-extrabold text-neutral-900 sm:text-4xl">{pageTitle}</h1>
-        <p class="text-neutral-600">Newest first, six posts per page.</p>
+        <p class="text-neutral-600">
+          Excludes the featured post, evergreen playbooks, and the five freshest stories to keep the homepage clean. Twelve posts per page.
+        </p>
       </div>
 
       <BlogList posts={pagePosts} currentPage={pageNumber} totalPages={totalPages} basePath="/posts" />

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,13 +1,18 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Homepage layout', () => {
-  test('shows hero, evergreen, latest, and all posts without duplicate slugs', async ({ page }) => {
+  test('shows featured, evergreen, and latest posts without duplicates', async ({ page }) => {
     await page.goto('/');
 
     await expect(page.getByTestId('hero-section')).toBeVisible();
     await expect(page.getByTestId('evergreen-section')).toBeVisible();
     await expect(page.getByTestId('latest-section')).toBeVisible();
-    await expect(page.getByTestId('all-posts-section')).toBeVisible();
+
+    const evergreenCards = page.getByTestId('evergreen-section').locator('a[href^="/posts/"]');
+    const latestCards = page.getByTestId('latest-section').locator('a[href^="/posts/"]');
+
+    await expect(evergreenCards).toHaveCount(4);
+    await expect(latestCards).toHaveCount(5);
 
     const slugs = await page.locator('[data-testid$="-section"] a[href^="/posts/"]').evaluateAll((links) =>
       links
@@ -17,6 +22,28 @@ test.describe('Homepage layout', () => {
 
     const unique = new Set(slugs);
     expect(unique.size).toBe(slugs.length);
+  });
+
+  test('latest posts exclude featured and evergreen content', async ({ page }) => {
+    await page.goto('/');
+
+    const heroSlug = await page.getByTestId('hero-section').locator('a[href^="/posts/"]').first().getAttribute('href');
+    const evergreenSlugs = await page
+      .getByTestId('evergreen-section')
+      .locator('a[href^="/posts/"]')
+      .evaluateAll((links) => links.map((link) => link.getAttribute('href')));
+
+    const latestSlugs = await page
+      .getByTestId('latest-section')
+      .locator('a[href^="/posts/"]')
+      .evaluateAll((links) => links.map((link) => link.getAttribute('href')));
+
+    const normalizedHero = heroSlug?.replace(/\/posts\/|\/$/g, '');
+    const normalizedEvergreen = evergreenSlugs.map((href) => (href ?? '').replace(/\/posts\/|\/$/g, ''));
+    const normalizedLatest = latestSlugs.map((href) => (href ?? '').replace(/\/posts\/|\/$/g, ''));
+
+    expect(normalizedLatest).not.toContain(normalizedHero);
+    normalizedEvergreen.forEach((slug) => expect(normalizedLatest).not.toContain(slug));
   });
 
   test('hides newsletter and version switchers', async ({ page }) => {

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,19 +1,41 @@
 import { expect, test } from '@playwright/test';
+import { TOPIC_CATEGORIES } from '../src/data/categories';
 
-test('desktop navigation routes to posts', async ({ page }) => {
+test('desktop navigation links to the Survival Library and shows Survival Areas dropdown', async ({ page }) => {
   await page.goto('/');
-  await page.getByRole('link', { name: 'All Posts' }).click();
+
+  await expect(page.getByRole('link', { name: 'Drops' })).toHaveCount(0);
+
+  const logoColor = await page.getByTestId('nav-logo').evaluate((el) => getComputedStyle(el).color);
+  expect(logoColor).toContain('255, 255, 255');
+
+  await page.getByRole('link', { name: 'Survival Library' }).click();
   await expect(page).toHaveURL(/\/posts\/$/);
+
+  await page.goto('/');
+  const dropdownTrigger = page.getByRole('button', { name: 'Survival Areas' });
+  await dropdownTrigger.click();
+
+  const categoryLabels = TOPIC_CATEGORIES.map((category) => category.label);
+  for (const label of categoryLabels) {
+    await expect(page.getByTestId('survival-areas-desktop').getByRole('link', { name: label })).toBeVisible();
+  }
 });
 
-test('mobile navigation toggles and routes', async ({ page }) => {
+test('mobile navigation toggles Survival Library and Survival Areas', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/');
 
   await page.getByTestId('mobile-menu-toggle').click();
-  const allPostsLink = page.getByRole('link', { name: 'All Posts' });
-  await expect(allPostsLink).toBeVisible();
-  await allPostsLink.click();
+  await expect(page.getByRole('link', { name: 'Survival Library' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Drops' })).toHaveCount(0);
 
-  await expect(page).toHaveURL(/\/posts\/$/);
+  const mobileDropdown = page.getByTestId('survival-areas-mobile').getByRole('button', { name: 'Survival Areas' });
+  await mobileDropdown.press('Enter');
+
+  const firstCategory = TOPIC_CATEGORIES[0];
+  await page.getByTestId(`survival-area-${firstCategory.key}-mobile`).click();
+
+  await expect(page).toHaveURL(new RegExp(`/category/${firstCategory.key}/`));
+  await expect(page.getByRole('heading', { level: 1 })).toContainText(firstCategory.label);
 });


### PR DESCRIPTION
### Motivation
- Remove legacy "Drops"/versioning UI and provide a clear, accessible navigation for the site’s primary content surfaces.
- Ensure homepage shows one featured post, up to four evergreen playbooks, and the next five latest posts with zero duplication.
- Move rolled-off content into a dedicated paginated archive called the `Survival Library` and expose topic-based `Survival Areas` driven by `TOPIC_CATEGORIES`.
- Improve navbar contrast and keyboard/screen-reader accessibility and add reliable Playwright coverage for the new behaviors.

### Description
- Reworked post sectioning in `src/utils/postSections.ts` with constants `EVERGREEN_SECTION_MAX = 4`, `LATEST_SECTION_SIZE = 5`, and `SURVIVAL_LIBRARY_PAGE_SIZE = 12`, and updated `buildSections`/`paginatePosts` to ensure exclusive segmentation (featured → evergreen → latest → remaining).
- Replaced nav/menu labels and behavior in `src/components/Navbar.astro` to remove `Drops`, relabel `All Posts` → `Survival Library`, add an accessible `Survival Areas` dropdown populated from `TOPIC_CATEGORIES`, and improve dark-mode contrast and keyboard handling.
- Moved archive behavior to the Survival Library: `src/pages/posts/index.astro` and `src/pages/posts/page/[page].astro` now serve the `remaining` posts only (paginated at 12 per page); `src/pages/category/[key].astro` added for category archives and sitemap updated to include category pages and remove the `/drops` entry.
- Updated UI copy and footer (`Survival Library`), added `data-testid` attributes to critical nav/list elements, and set frontmatter flags (`featured`/`evergreen`) on several content files to align demo content with the new rules.

### Testing
- Updated Playwright test suite in `tests/` to assert: hero shows featured post, evergreen shows up to 4 posts, latest shows 5 non-duplicate posts, `/posts` excludes homepage posts and paginates at 12, Survival Areas dropdown presence and links, and nav contrast via `nav-logo` style checks.
- Tests were executed via `npm test` but the Playwright runner could not be installed in CI/dev due to `403` from npm registry when fetching `@playwright/test`, so the suite did not run to completion.
- All tests were refactored to use reliable selectors (`data-testid`, semantic roles) and to reflect new labels/paths (`Survival Library`, `Survival Areas`).
- If dependency installation is available (`npm install`) the updated test suite is ready to run with `npm test` (Playwright web server is driven by the existing `npm run dev` command).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c81c9db6c83268ec075a58025837d)