### PR TITLE
Update header wordmark to stacked type-only wordmark with responsive tagline

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -10,8 +10,15 @@ const survivalAreas = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
 ---
 <nav class="bg-neutral-950 text-neutral-50 shadow-sm" data-testid="navbar">
   <div class="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4">
-    <a href="/" class="flex items-center gap-2 text-2xl font-bold tracking-tight text-white transition hover:text-neutral-50" data-testid="nav-logo">
-      Survive the AI
+    <a href="/" aria-label="SurviveTheAI home" class="flex items-start gap-2 text-white transition hover:text-neutral-50" data-testid="nav-logo">
+      <div class="flex flex-col leading-none">
+        <span class="text-xl sm:text-2xl md:text-3xl font-extrabold tracking-tight uppercase">Survive</span>
+        <div class="mt-0.5 text-sm sm:text-base md:text-lg font-semibold tracking-wide uppercase">
+          <span>THE </span>
+          <span class="text-orange-400">AI</span>
+        </div>
+        <span class="mt-1 hidden md:block text-xs md:text-sm font-medium opacity-70">The AI flood is here. Learn to swim.</span>
+      </div>
     </a>
     <div class="hidden items-center gap-2 md:flex">
       {links.map((link) => (


### PR DESCRIPTION
### Motivation
- Replace the simple "Survive the AI" site title with a stronger type-only wordmark that conveys a "survival mode" treatment.
- Keep the existing header layout, click target, and accessibility while using Tailwind utility classes only and avoiding any font changes.
- Make the tagline stacked under the mark and responsive so it is hidden on small screens to avoid cramping navigation.
- Ensure color accenting for `AI` using the project orange token and preserve readability in light/dark modes.

### Description
- Replaced the brand anchor content in `src/components/Navbar.astro` with a stacked flex column containing `Survive` (large, uppercase), `THE AI` (smaller with `AI` in `text-orange-400`), and the tagline `The AI flood is here. Learn to swim.`
- Added `aria-label="SurviveTheAI home"` to the link and kept the anchor target as `/` so click behavior and semantics are preserved.
- Applied Tailwind utility classes for responsive sizing and spacing (`flex flex-col leading-none`, `text-xl sm:text-2xl md:text-3xl`, `hidden md:block`, etc.) and intentionally avoided adding any new web fonts.
- Kept all other header markup and interactive behavior unchanged so navigation, dropdowns, and mobile menu continue to work.

### Testing
- Ran `npm run build` which completed successfully and produced the static site output without build errors.
- Ran `npm test` which failed because Playwright is not available in the environment (`sh: 1: playwright: not found`).
- Attempted `npm install` to restore test deps but the install was blocked by the registry with a `403` error, preventing `@playwright/test` from being installed.
- Launched the dev server and executed an automated Playwright Python script to capture desktop and mobile screenshots, which completed and produced header screenshots for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c9222911c83268abbf085799be9fe)