### PR TITLE
Hide author byline, gate playbook offer, fix right-rail cards, and conditional TOC

### DIFF
--- a/src/components/Byline.tsx
+++ b/src/components/Byline.tsx
@@ -8,15 +8,21 @@ type BylineProps = {
 };
 
 const Byline: FC<BylineProps> = ({ author, displayDate, isoDate, readingTime }) => {
+  const showAuthor = import.meta.env.PUBLIC_SHOW_AUTHOR === 'true';
+
   return (
-    <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-500">
-      <span className="font-medium text-neutral-300">{author}</span>
-      <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-700 sm:block" />
-      <time dateTime={isoDate} className="text-neutral-500">
+    <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-600 dark:text-neutral-300">
+      {showAuthor && (
+        <>
+          <span className="font-medium text-neutral-800 dark:text-neutral-200">{author}</span>
+          <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-400 dark:bg-neutral-600 sm:block" />
+        </>
+      )}
+      <time dateTime={isoDate} className="text-neutral-600 dark:text-neutral-300">
         {displayDate}
       </time>
-      <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-700 sm:block" />
-      <span>{readingTime}</span>
+      <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-400 dark:bg-neutral-600 sm:block" />
+      <span className="text-neutral-600 dark:text-neutral-300">{readingTime}</span>
     </div>
   );
 };

--- a/src/components/RightRailRelated.astro
+++ b/src/components/RightRailRelated.astro
@@ -33,26 +33,36 @@ const related = (relatedPool.length >= 3 ? relatedPool : sortedPosts).slice(0, 5
     {related.map((entry) => {
       const heroImage = entry.data.heroImage;
       const dateLabel = formatDate(entry.data.date);
+      const hasHero = typeof heroImage === 'string' && heroImage.trim().length > 0;
 
       return (
         <li>
-          <a href={`/posts/${entry.slug}/`} class="group flex items-center gap-4 rounded-2xl border border-neutral-200 p-2 transition hover:border-neutral-300 hover:bg-neutral-50">
-            <div class="h-14 w-14 overflow-hidden rounded-xl bg-neutral-100">
-              <img
-                src={heroImage}
-                alt={entry.data.title}
-                loading="lazy"
-                decoding="async"
-                width="56"
-                height="56"
-                class="h-full w-full object-cover"
-              />
+          <a href={`/posts/${entry.slug}/`} class="group flex items-center gap-4 rounded-2xl border border-neutral-200 p-2 transition hover:border-neutral-300 hover:bg-neutral-50 dark:border-neutral-800 dark:hover:border-neutral-700 dark:hover:bg-neutral-800/60">
+            <div class="relative h-14 w-14 overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-800/70">
+              {hasHero && (
+                <img
+                  src={heroImage}
+                  alt={entry.data.title}
+                  loading="lazy"
+                  decoding="async"
+                  width="56"
+                  height="56"
+                  class="h-full w-full object-cover"
+                  onerror="this.style.display='none'; const placeholder = this.nextElementSibling; if (placeholder) placeholder.classList.remove('hidden');"
+                />
+              )}
+              <div class={`absolute inset-0 flex items-center justify-center text-[10px] font-medium text-neutral-400 dark:text-neutral-500 ${hasHero ? 'hidden' : ''}`}>
+                No image
+              </div>
             </div>
             <div class="space-y-1">
-              <p class="text-sm font-medium text-neutral-900 transition group-hover:text-neutral-700">
+              <p
+                class="text-sm font-semibold text-neutral-900 transition group-hover:text-neutral-700 dark:text-neutral-50 dark:group-hover:text-neutral-200"
+                style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;"
+              >
                 {entry.data.title}
               </p>
-              <p class="text-xs text-neutral-600">{dateLabel}</p>
+              <p class="text-xs text-neutral-600 dark:text-neutral-400">{dateLabel}</p>
             </div>
           </a>
         </li>

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -22,7 +22,7 @@ const TableOfContents: FC<TableOfContentsProps> = ({
   const filtered = useMemo(() => headings.filter((heading) => heading.depth === 2 || heading.depth === 3), [headings]);
   const [collapsed, setCollapsed] = useState(initiallyCollapsed);
 
-  if (filtered.length === 0) {
+  if (filtered.length < 4) {
     return null;
   }
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -31,6 +31,7 @@ const readingTimeLabel = formatReadingMinutes(readingTime);
 const isoDate = date.toISOString();
 const heroAlt = heroImageAlt ?? `${title} hero image`;
 const filteredHeadings = headings.filter((heading) => heading.depth === 2 || heading.depth === 3);
+const tocHeadings = filteredHeadings.length >= 4 ? filteredHeadings : [];
 const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
 const primaryCategory = topics?.[0] ? categoryByKey.get(topics[0]) : undefined;
 const categoryLabel = primaryCategory?.label;
@@ -103,7 +104,11 @@ const structuredData = {
             </div>
             <slot name="heading">
               <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl">{title}</h1>
-              {description && <p class="text-base text-neutral-700 sm:text-lg">{description}</p>}
+              {description && (
+                <p class="text-lg text-neutral-700 dark:text-neutral-200 sm:text-xl">
+                  {description}
+                </p>
+              )}
             </slot>
             <div class="lg:hidden">
               <slot name="share-bar-top">
@@ -119,11 +124,6 @@ const structuredData = {
             readingTime={readingTimeLabel}
           />
           <slot name="inline-cta" />
-          {filteredHeadings.length > 0 && (
-            <div class="lg:hidden">
-              <TableOfContents client:load headings={filteredHeadings} initiallyCollapsed={true} />
-            </div>
-          )}
           <article class="mx-auto w-full max-w-[760px] prose prose-neutral text-neutral-900 prose-headings:font-extrabold prose-a:underline-offset-2 dark:prose-invert dark:text-neutral-100">
             <slot />
           </article>
@@ -136,9 +136,9 @@ const structuredData = {
         <aside class="space-y-8 lg:col-span-4">
           <div class="space-y-8 lg:sticky lg:top-24">
             <RightRailRelated currentSlug={post.slug} posts={allPosts} />
-            {filteredHeadings.length > 0 && (
+            {tocHeadings.length > 0 && (
               <div class="hidden lg:block">
-                <TableOfContents client:load headings={filteredHeadings} initiallyCollapsed={false} />
+                <TableOfContents client:load headings={tocHeadings} initiallyCollapsed={false} />
               </div>
             )}
           </div>

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -16,6 +16,8 @@ const { Content, headings } = await post.render();
 const { minutes } = readingTime(post.body ?? '');
 const shareUrl = post.data.canonicalUrl || new URL(`/posts/${post.slug}/`, Astro.site ?? 'https://survivetheai.com').toString();
 const affiliate = post.data.affiliate_offer;
+// Toggle via PUBLIC_SHOW_PLAYBOOK_OFFER=true to re-enable the inline playbook offer block.
+const showPlaybookOffer = import.meta.env.PUBLIC_SHOW_PLAYBOOK_OFFER === 'true';
 ---
 <PostLayout
   post={post}
@@ -24,7 +26,7 @@ const affiliate = post.data.affiliate_offer;
   shareUrl={shareUrl}
   allPosts={allPosts}
 >
-  {affiliate && (
+  {showPlaybookOffer && affiliate && (
     <div
       slot="inline-cta"
       class="space-y-4 rounded-3xl border border-neutral-200 bg-neutral-50 p-6 shadow-[0_10px_30px_-20px_rgba(0,0,0,0.12)]"


### PR DESCRIPTION
### Motivation

- Remove visible author names from post headers to avoid a personal-blog feel while preserving author data for SEO and internal use.  
- Temporarily hide the “Get the Survival Playbook” featured offer until it is ready, using a feature flag rather than deleting the component.  
- Repair the right-rail related-post cards so titles render, long titles clamp to two lines, and missing/broken thumbnails show a clean placeholder.  
- Remove duplicated TOC and only show a single, useful TOC on desktop for posts with sufficient headings to be valuable.

### Description

- Added an environment flag `PUBLIC_SHOW_AUTHOR` (default off) and updated `src/components/Byline.tsx` to stop rendering the author line while preserving the `author` frontmatter and JSON-LD structured data.  
- Added an environment flag `PUBLIC_SHOW_PLAYBOOK_OFFER` (default off) and gated the featured offer block in `src/pages/posts/[slug].astro` so it can be re-enabled with `PUBLIC_SHOW_PLAYBOOK_OFFER=true`.  
- Fixed right-rail cards in `src/components/RightRailRelated.astro` to always render the post title (2-line clamp), improve dark-mode styles, and render a neutral placeholder instead of a broken image when `heroImage` is missing or fails to load.  
- Consolidated and conditioned the table-of-contents logic by changing `src/components/TableOfContents.tsx` to render only when there are 4+ headings and updating `src/layouts/PostLayout.astro` to show the TOC only once (desktop only) and to slightly increase subtitle contrast/size for readability.

### Testing

- Attempted `npm install` but dependency installation failed due to a registry 403 response so automated install/build steps could not run.  
- `npm run build` was not executed because dependencies were not installed.  
- `npm test` (`playwright test`) was not run for the same reason.  
- Code changes were committed locally and staged in a PR for review; behavior verification is pending a successful install/build in CI or a local dev environment with network access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c9e1cebd8832687f2fcfc4e1798e9)