### PR TITLE
Fix: include global Navbar on post pages by rendering shared Navbar in PostLayout

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,4 +1,5 @@
 ---
+import Navbar from '../components/Navbar.astro';
 import HeroImage from '../components/HeroImage.astro';
 import Byline from '../components/Byline.tsx';
 import RightRailRelated from '../components/RightRailRelated.astro';
@@ -90,6 +91,7 @@ const structuredData = {
     </script>
   </head>
   <body class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100 antialiased">
+    <Navbar />
     <div class="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
       <div class="lg:grid lg:grid-cols-12 lg:gap-10">
         <main class="pb-16 space-y-6 sm:space-y-8 lg:col-span-8">


### PR DESCRIPTION
### Motivation
- Posts were rendering a separate full HTML scaffold in `src/layouts/PostLayout.astro` and did not include the global navigation, causing the top menu to be missing on individual post pages.
- The goal is to render the same shared top navigation used by other pages with minimal changes and no SEO or layout regressions.

### Description
- Import the shared `Navbar` component (`../components/Navbar.astro`) into `src/layouts/PostLayout.astro`.
- Render `<Navbar />` immediately inside the `<body>` of the post layout, above the post container, mirroring `BaseLayout` placement.
- Kept all existing post hero/header, meta, and structured data logic intact to avoid SEO or visual regressions.
- Only `src/layouts/PostLayout.astro` was modified to minimize churn.

### Testing
- Ran `npm run build`, which failed because `astro` was not found due to missing dependencies and therefore the build did not complete.
- Ran `npm install` to fetch dependencies, which failed due to repeated registry HTTP 403 responses and blocked a successful build.
- No automated site-build or unit tests could be completed because dependency installation was blocked by the registry errors.
- Manual inspection of the layout change shows `Navbar` is imported and rendered in `PostLayout.astro` as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ca51bfecc83269d6decf5fd5907f4)