### PR TITLE
P0: Lock light theme and normalize post grids/cards

### DIFF
--- a/src/components/BlogList.astro
+++ b/src/components/BlogList.astro
@@ -1,7 +1,6 @@
 ---
 import type { PostEntry } from '../content/config';
-import { formatDate } from '../utils/format';
-import { TOPIC_CATEGORIES } from '../data/categories';
+import PostCard from './PostCard.astro';
 
 const { posts, currentPage, totalPages, basePath } = Astro.props as {
   posts: PostEntry[];
@@ -10,44 +9,15 @@ const { posts, currentPage, totalPages, basePath } = Astro.props as {
   basePath: string;
 };
 
-const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
 const normalizedBasePath = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
 const buildPageHref = (page: number) => (page === 1 ? `${normalizedBasePath}/` : `${normalizedBasePath}/page/${page}/`);
 ---
 
 <div class="space-y-8" data-testid="blog-list" data-total-pages={totalPages} data-current-page={currentPage}>
-  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    {posts.map((post) => {
-      const primaryCategory = post.data.topics?.[0] ? categoryByKey.get(post.data.topics[0]) : undefined;
-      return (
-        <article class="flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300">
-          <a href={`/posts/${post.slug}/`} class="block">
-            <img
-              src={post.data.heroImageThumb ?? post.data.heroImage}
-              alt={post.data.heroImageAlt ?? post.data.title}
-              class="h-48 w-full object-cover"
-              loading="lazy"
-              decoding="async"
-              width="640"
-              height="360"
-            />
-          </a>
-          <div class="flex flex-1 flex-col gap-3 p-5">
-            <div class="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-500">
-              <span>{primaryCategory?.label ?? post.data.category ?? 'Key Topic'}</span>
-              <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
-              <span>{formatDate(post.data.date)}</span>
-            </div>
-            <h3 class="text-lg font-semibold text-neutral-900">
-              <a href={`/posts/${post.slug}/`} class="transition hover:text-neutral-700">
-                {post.data.title}
-              </a>
-            </h3>
-            <p class="text-sm text-neutral-700">{post.data.description}</p>
-          </div>
-        </article>
-      );
-    })}
+  <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    {posts.map((post) => (
+      <PostCard post={post} />
+    ))}
   </div>
 
   {totalPages > 1 && (

--- a/src/components/Byline.tsx
+++ b/src/components/Byline.tsx
@@ -11,18 +11,18 @@ const Byline: FC<BylineProps> = ({ author, displayDate, isoDate, readingTime }) 
   const showAuthor = import.meta.env.PUBLIC_SHOW_AUTHOR === 'true';
 
   return (
-    <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-600 dark:text-neutral-300">
+    <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-600">
       {showAuthor && (
         <>
-          <span className="font-medium text-neutral-800 dark:text-neutral-200">{author}</span>
-          <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-400 dark:bg-neutral-600 sm:block" />
+          <span className="font-medium text-neutral-800">{author}</span>
+          <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-400 sm:block" />
         </>
       )}
-      <time dateTime={isoDate} className="text-neutral-600 dark:text-neutral-300">
+      <time dateTime={isoDate} className="text-neutral-600">
         {displayDate}
       </time>
-      <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-400 dark:bg-neutral-600 sm:block" />
-      <span className="text-neutral-600 dark:text-neutral-300">{readingTime}</span>
+      <span aria-hidden className="hidden h-1 w-1 rounded-full bg-neutral-400 sm:block" />
+      <span className="text-neutral-600">{readingTime}</span>
     </div>
   );
 };

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -8,23 +8,23 @@ const links = [
 
 const survivalAreas = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
 ---
-<nav class="bg-neutral-950 text-neutral-50 shadow-sm" data-testid="navbar">
+<nav class="bg-white text-neutral-900 shadow-sm border-b border-neutral-200" data-testid="navbar">
   <div class="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4">
-    <a href="/" aria-label="SurviveTheAI home" class="flex items-start gap-2 text-white transition hover:text-neutral-50" data-testid="nav-logo">
+    <a href="/" aria-label="SurviveTheAI home" class="flex items-start gap-2 text-neutral-900 transition hover:text-neutral-700" data-testid="nav-logo">
       <div class="flex flex-col leading-none">
         <span class="text-xl sm:text-2xl md:text-3xl font-extrabold tracking-tight uppercase">Survive</span>
         <div class="mt-0.5 text-sm sm:text-base md:text-lg font-semibold tracking-wide uppercase">
           <span>THE </span>
-          <span class="text-orange-400">AI</span>
+          <span class="text-orange-500">AI</span>
         </div>
-        <span class="mt-1 hidden md:block text-xs md:text-sm font-medium opacity-70">The AI flood is here. Learn to swim.</span>
+        <span class="mt-1 hidden md:block text-xs md:text-sm font-medium text-neutral-500">The AI flood is here. Learn to swim.</span>
       </div>
     </a>
     <div class="hidden items-center gap-2 md:flex">
       {links.map((link) => (
         <a
           href={link.href}
-          class="rounded-full px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          class="rounded-full px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
           data-testid={link.testId}
         >
           {link.label}
@@ -33,7 +33,7 @@ const survivalAreas = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
       <div class="relative" data-testid="survival-areas-desktop">
         <button
           type="button"
-          class="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          class="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
           aria-haspopup="true"
           aria-expanded="false"
           aria-controls="desktop-survival-areas"
@@ -54,13 +54,13 @@ const survivalAreas = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
           role="menu"
           data-dropdown-menu
           data-open="false"
-          class="absolute right-0 z-20 mt-3 hidden min-w-[240px] rounded-2xl bg-neutral-900/95 p-2 shadow-2xl ring-1 ring-white/15 backdrop-blur data-[open=true]:flex data-[open=true]:flex-col"
+          class="absolute right-0 z-20 mt-3 hidden min-w-[240px] rounded-2xl bg-white p-2 shadow-2xl ring-1 ring-neutral-200 data-[open=true]:flex data-[open=true]:flex-col"
         >
           {survivalAreas.map((area) => (
             <a
               href={`/category/${area.key}/`}
               role="menuitem"
-              class="rounded-xl px-4 py-3 text-sm font-semibold text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+              class="rounded-xl px-4 py-3 text-sm font-semibold text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
               data-testid={`survival-area-${area.key}`}
             >
               {area.label}
@@ -71,7 +71,7 @@ const survivalAreas = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
     </div>
     <button
       type="button"
-      class="inline-flex items-center justify-center rounded-full p-2 text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 md:hidden"
+      class="inline-flex items-center justify-center rounded-full p-2 text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 md:hidden"
       aria-label="Toggle navigation menu"
       aria-expanded="false"
       aria-controls="mobile-menu"
@@ -83,21 +83,21 @@ const survivalAreas = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
       </svg>
     </button>
   </div>
-  <div id="mobile-menu" class="hidden border-t border-white/10 bg-neutral-900 md:hidden" data-testid="mobile-menu">
+  <div id="mobile-menu" class="hidden border-t border-neutral-200 bg-white md:hidden" data-testid="mobile-menu">
     <div class="mx-auto flex max-w-7xl flex-col gap-2 px-4 py-4">
       {links.map((link) => (
         <a
           href={link.href}
-          class="rounded-xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          class="rounded-xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
           data-testid={`${link.testId}-mobile`}
         >
           {link.label}
         </a>
       ))}
-      <div class="border-t border-white/10 pt-3" data-testid="survival-areas-mobile">
+      <div class="border-t border-neutral-200 pt-3" data-testid="survival-areas-mobile">
         <button
           type="button"
-          class="flex w-full items-center justify-between rounded-xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          class="flex w-full items-center justify-between rounded-xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
           aria-haspopup="true"
           aria-expanded="false"
           aria-controls="mobile-survival-areas"
@@ -118,13 +118,13 @@ const survivalAreas = [...TOPIC_CATEGORIES].sort((a, b) => a.order - b.order);
           role="menu"
           data-dropdown-menu
           data-open="false"
-          class="mt-2 hidden flex-col gap-2 rounded-xl bg-neutral-900/60 p-2 ring-1 ring-white/10 data-[open=true]:flex"
+          class="mt-2 hidden flex-col gap-2 rounded-xl bg-white p-2 ring-1 ring-neutral-200 data-[open=true]:flex"
         >
           {survivalAreas.map((area) => (
             <a
               href={`/category/${area.key}/`}
               role="menuitem"
-              class="rounded-lg px-4 py-3 text-sm font-semibold text-neutral-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+              class="rounded-lg px-4 py-3 text-sm font-semibold text-neutral-800 transition hover:bg-neutral-100 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
               data-testid={`survival-area-${area.key}-mobile`}
             >
               {area.label}

--- a/src/components/NewsletterSignup.astro
+++ b/src/components/NewsletterSignup.astro
@@ -1,4 +1,4 @@
-<div class="bg-white dark:bg-gray-800 p-5 rounded-lg shadow-sm">
+<div class="bg-white p-5 rounded-lg shadow-sm">
   <h3 class="text-md font-bold mb-3">Sign up for updates</h3>
   <form class="space-y-2">
     <input type="email" id="email" name="email" placeholder="Your email" class="border border-[var(--primary)] rounded px-2 py-1" required />

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,29 +1,45 @@
 ---
+import type { PostEntry } from '../content/config';
 import { TOPIC_CATEGORIES } from '../data/categories';
-const { title, excerpt, imageUrl, topics, date, category } = Astro.props;
+import { formatDate } from '../utils/format';
 
-// Find the category object for this post
-const catObj =
-  (Array.isArray(topics) && TOPIC_CATEGORIES.find((cat) => cat.key === topics[0])) ||
-  TOPIC_CATEGORIES.find((cat) => cat.label === category);
+const { post } = Astro.props as { post: PostEntry };
+
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
+const primaryCategory = post.data.topics?.[0] ? categoryByKey.get(post.data.topics[0]) : undefined;
+const categoryLabel = primaryCategory?.label ?? post.data.category ?? 'Key Topic';
+const dateLabel = formatDate(post.data.date);
+const imageSrc = post.data.heroImageThumb ?? post.data.heroImage;
+const imageAlt = post.data.heroImageAlt ?? post.data.title;
 ---
 
-<article class="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition duration-200 border border-gray-200 dark:border-gray-700">
-  <img src={imageUrl} alt={title} class="w-full h-48 object-cover" />
-
-  <div class="p-5">
-    <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mb-2">
-      <span
-        class="px-2 py-0.5 rounded font-semibold"
-        style={`background:${catObj?.color ?? '#eee'}; color:#222;`}
-        title={catObj?.description}
-      >
-        {/* Optionally render icon here if you have an icon component */}
-        {catObj ? catObj.label : category}
-      </span>
-      <span>{date}</span>
-    </div>
-    <h3 class="text-lg font-bold text-gray-900 dark:text-white mb-1">{title}</h3>
-    <p class="text-sm text-gray-600 dark:text-gray-300">{excerpt}</p>
+<a
+  href={`/posts/${post.slug}/`}
+  class="group flex h-full flex-col overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400"
+>
+  <div class="relative aspect-[16/9] overflow-hidden bg-neutral-100">
+    <img
+      src={imageSrc}
+      alt={imageAlt}
+      loading="lazy"
+      decoding="async"
+      width="640"
+      height="360"
+      class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
+    />
   </div>
-</article>
+  <div class="flex flex-1 flex-col gap-3 p-5">
+    <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.28em] text-neutral-600">
+      <span>{categoryLabel}</span>
+      <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+      <span>{dateLabel}</span>
+    </div>
+    <h3 class="text-lg font-semibold leading-tight text-neutral-900 transition group-hover:text-neutral-700 line-clamp-2">
+      {post.data.title}
+    </h3>
+    <p class="text-sm leading-relaxed text-neutral-700 line-clamp-3">{post.data.description}</p>
+    <div class="mt-auto flex items-center text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">
+      <span>Impact Score {post.data.impact_score}</span>
+    </div>
+  </div>
+</a>

--- a/src/components/PostGrid.astro
+++ b/src/components/PostGrid.astro
@@ -1,6 +1,7 @@
 ---
 import type { Post } from '../data/Posts';
 import { TOPIC_CATEGORIES } from '../data/categories';
+import PostCard from './PostCard.astro';
 
 const { groupedItems } = Astro.props as { groupedItems: Post[][] };
 
@@ -18,7 +19,9 @@ const primaryLabel = (keys?: string[]) => {
       <div class="mb-6">
         <a href={`/posts/${first.slug}/`} class="block">
           <div class="flex flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-lg transition hover:border-neutral-300">
-            <img src={first.data.heroImage} alt={first.data.heroImageAlt ?? first.data.title} class="h-80 w-full object-cover" loading="lazy" decoding="async" width="1200" height="630" />
+            <div class="relative aspect-[16/9] bg-neutral-100">
+              <img src={first.data.heroImage} alt={first.data.heroImageAlt ?? first.data.title} class="absolute inset-0 h-full w-full object-cover" loading="lazy" decoding="async" width="1200" height="630" />
+            </div>
             <div class="flex flex-1 flex-col gap-4 p-6">
               <div class="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-neutral-500">
                 <span>{primaryLabel(first.data.topics) ?? first.data.category}</span>
@@ -33,22 +36,9 @@ const primaryLabel = (keys?: string[]) => {
       </div>
 
       {rest.length > 0 && (
-        <div class="mb-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {rest.map((post) => (
-            <a key={post.slug} href={`/posts/${post.slug}/`} class="block">
-              <div class="flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white transition hover:border-neutral-300 shadow">
-                <img src={post.data.heroImageThumb ?? post.data.heroImage} alt={post.data.heroImageAlt ?? post.data.title} class="h-40 w-full object-cover" loading="lazy" decoding="async" width="400" height="210" />
-                <div class="flex flex-1 flex-col gap-3 p-5">
-                  <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
-                    <span>{primaryLabel(post.data.topics) ?? post.data.category}</span>
-                    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
-                    <span>{post.data.impact_score}</span>
-                  </div>
-                  <h3 class="text-lg font-semibold text-neutral-900">{post.data.title}</h3>
-                  <p class="text-sm text-neutral-700">{post.data.description}</p>
-                </div>
-              </div>
-            </a>
+            <PostCard post={post} />
           ))}
         </div>
       )}

--- a/src/components/RightRailRelated.astro
+++ b/src/components/RightRailRelated.astro
@@ -37,8 +37,8 @@ const related = (relatedPool.length >= 3 ? relatedPool : sortedPosts).slice(0, 5
 
       return (
         <li>
-          <a href={`/posts/${entry.slug}/`} class="group flex items-center gap-4 rounded-2xl border border-neutral-200 p-2 transition hover:border-neutral-300 hover:bg-neutral-50 dark:border-neutral-800 dark:hover:border-neutral-700 dark:hover:bg-neutral-800/60">
-            <div class="relative h-14 w-14 overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-800/70">
+          <a href={`/posts/${entry.slug}/`} class="group flex items-center gap-4 rounded-2xl border border-neutral-200 p-2 transition hover:border-neutral-300 hover:bg-neutral-50">
+            <div class="relative h-14 w-14 overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50">
               {hasHero && (
                 <img
                   src={heroImage}
@@ -51,18 +51,18 @@ const related = (relatedPool.length >= 3 ? relatedPool : sortedPosts).slice(0, 5
                   onerror="this.style.display='none'; const placeholder = this.nextElementSibling; if (placeholder) placeholder.classList.remove('hidden');"
                 />
               )}
-              <div class={`absolute inset-0 flex items-center justify-center text-[10px] font-medium text-neutral-400 dark:text-neutral-500 ${hasHero ? 'hidden' : ''}`}>
+              <div class={`absolute inset-0 flex items-center justify-center text-[10px] font-medium text-neutral-400 ${hasHero ? 'hidden' : ''}`}>
                 No image
               </div>
             </div>
             <div class="space-y-1">
               <p
-                class="text-sm font-semibold text-neutral-900 transition group-hover:text-neutral-700 dark:text-neutral-50 dark:group-hover:text-neutral-200"
+                class="text-sm font-semibold text-neutral-900 transition group-hover:text-neutral-700"
                 style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;"
               >
                 {entry.data.title}
               </p>
-              <p class="text-xs text-neutral-600 dark:text-neutral-400">{dateLabel}</p>
+              <p class="text-xs text-neutral-600">{dateLabel}</p>
             </div>
           </a>
         </li>

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -32,12 +32,12 @@ const TableOfContents: FC<TableOfContentsProps> = ({
 
   return (
     <nav
-      className={`rounded-3xl border border-neutral-200 bg-white p-5 text-sm text-neutral-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 ${className}`.trim()}
+      className={`rounded-3xl border border-neutral-200 bg-white p-5 text-sm text-neutral-700 shadow-sm ${className}`.trim()}
       aria-label="Table of contents"
     >
       <button
         type="button"
-        className="flex w-full items-center justify-between gap-2 text-left font-medium text-neutral-800 dark:text-neutral-100 lg:cursor-auto"
+        className="flex w-full items-center justify-between gap-2 text-left font-medium text-neutral-800 lg:cursor-auto"
         onClick={() => setCollapsed((value) => !value)}
         aria-expanded={!collapsed}
       >
@@ -54,10 +54,10 @@ const TableOfContents: FC<TableOfContentsProps> = ({
       </button>
       <ul className={listClasses}>
         {filtered.map((heading) => (
-          <li key={heading.slug} className={heading.depth === 3 ? 'pl-4 text-neutral-500 dark:text-neutral-400' : ''}>
+          <li key={heading.slug} className={heading.depth === 3 ? 'pl-4 text-neutral-500' : ''}>
             <a
               href={`#${heading.slug}`}
-              className="block rounded-md px-2 py-1 transition hover:text-neutral-900 dark:hover:text-neutral-100"
+              className="block rounded-md px-2 py-1 transition hover:text-neutral-900"
             >
               {heading.text}
             </a>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,27 +13,14 @@ const {
 ---
 
 <!DOCTYPE html>
-<html lang="en" class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
+<html lang="en" class="bg-white text-neutral-900">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <title>{title}</title>
-    <script is:inline>
-      (function() {
-        try {
-          const stored = localStorage.getItem('theme');
-          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-          const useDark = stored ? stored === 'dark' : prefersDark;
-          document.documentElement.classList.toggle('dark', useDark);
-        } catch (e) {
-          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-          if (prefersDark) document.documentElement.classList.add('dark');
-        }
-      })();
-    </script>
   </head>
-  <body class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100 font-sans">
+  <body class="bg-white text-neutral-900 font-sans antialiased">
     <Navbar />
     <main class="min-h-screen">
       <slot />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -57,7 +57,7 @@ const structuredData = {
 };
 ---
 <!DOCTYPE html>
-<html lang="en" class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
+<html lang="en" class="bg-white text-neutral-900">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -76,21 +76,8 @@ const structuredData = {
     <meta name="twitter:image" content={heroImage.startsWith('http') ? heroImage : new URL(heroImage, canonicalUrl).toString()} />
     <title>{title} · Survive the AI</title>
     <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
-    <script is:inline>
-      (function() {
-        try {
-          const stored = localStorage.getItem('theme');
-          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-          const useDark = stored ? stored === 'dark' : prefersDark;
-          document.documentElement.classList.toggle('dark', useDark);
-        } catch (e) {
-          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-          if (prefersDark) document.documentElement.classList.add('dark');
-        }
-      })();
-    </script>
   </head>
-  <body class="bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100 antialiased">
+  <body class="bg-white text-neutral-900 antialiased">
     <Navbar />
     <div class="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
       <div class="lg:grid lg:grid-cols-12 lg:gap-10">
@@ -107,7 +94,7 @@ const structuredData = {
             <slot name="heading">
               <h1 class="text-3xl font-extrabold tracking-tight text-neutral-900 sm:text-4xl">{title}</h1>
               {description && (
-                <p class="text-lg text-neutral-700 dark:text-neutral-200 sm:text-xl">
+                <p class="text-lg text-neutral-700 sm:text-xl">
                   {description}
                 </p>
               )}
@@ -126,7 +113,7 @@ const structuredData = {
             readingTime={readingTimeLabel}
           />
           <slot name="inline-cta" />
-          <article class="mx-auto w-full max-w-[760px] prose prose-neutral text-neutral-900 prose-headings:font-extrabold prose-a:underline-offset-2 dark:prose-invert dark:text-neutral-100">
+          <article class="prose text-neutral-900 prose-headings:font-extrabold">
             <slot />
           </article>
           <footer class="pt-6">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 import { buildSections } from '../utils/postSections';
 import { formatDate } from '../utils/format';
+import PostCard from '../components/PostCard.astro';
 
 const posts = await getCollection('posts');
 const { featured, evergreen, latest, remaining } = buildSections(posts);
@@ -39,16 +40,21 @@ const { featured, evergreen, latest, remaining } = buildSections(posts);
               </a>
             </div>
           </div>
-          <a href={`/posts/${featured.slug}/`} class="block overflow-hidden rounded-3xl shadow-lg ring-1 ring-neutral-200 transition hover:-translate-y-0.5 hover:shadow-xl">
-            <img
-              src={featured.data.heroImage}
-              alt={featured.data.heroImageAlt ?? featured.data.title}
-              class="h-full w-full object-cover"
-              loading="lazy"
-              decoding="async"
-              width="1200"
-              height="630"
-            />
+          <a
+            href={`/posts/${featured.slug}/`}
+            class="block overflow-hidden rounded-3xl shadow-lg ring-1 ring-neutral-200 transition hover:-translate-y-0.5 hover:shadow-xl"
+          >
+            <div class="relative aspect-[16/9] bg-neutral-100">
+              <img
+                src={featured.data.heroImage}
+                alt={featured.data.heroImageAlt ?? featured.data.title}
+                class="absolute inset-0 h-full w-full object-cover"
+                loading="lazy"
+                decoding="async"
+                width="1200"
+                height="630"
+              />
+            </div>
           </a>
         </section>
       ) : (
@@ -64,31 +70,9 @@ const { featured, evergreen, latest, remaining } = buildSections(posts);
             <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Evergreen</p>
             <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Playbooks that stay relevant</h2>
           </div>
-          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {evergreen.map((post) => (
-              <a
-                href={`/posts/${post.slug}/`}
-                class="flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300"
-              >
-                <img
-                  src={post.data.heroImageThumb ?? post.data.heroImage}
-                  alt={post.data.heroImageAlt ?? post.data.title}
-                  class="h-44 w-full object-cover"
-                  loading="lazy"
-                  decoding="async"
-                  width="640"
-                  height="360"
-                />
-                <div class="flex flex-1 flex-col gap-2 p-4">
-                  <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
-                    <span>Impact {post.data.impact_score}</span>
-                    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
-                    <span>{formatDate(post.data.date)}</span>
-                  </div>
-                  <h3 class="text-base font-semibold text-neutral-900">{post.data.title}</h3>
-                  <p class="text-sm text-neutral-700">{post.data.description}</p>
-                </div>
-              </a>
+              <PostCard post={post} />
             ))}
           </div>
         </section>
@@ -100,31 +84,9 @@ const { featured, evergreen, latest, remaining } = buildSections(posts);
             <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">Latest</p>
             <h2 class="text-2xl font-extrabold text-neutral-900 sm:text-3xl">Latest intelligence</h2>
           </div>
-          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {latest.map((post) => (
-              <a
-                href={`/posts/${post.slug}/`}
-                class="flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300"
-              >
-                <img
-                  src={post.data.heroImageThumb ?? post.data.heroImage}
-                  alt={post.data.heroImageAlt ?? post.data.title}
-                  class="h-44 w-full object-cover"
-                  loading="lazy"
-                  decoding="async"
-                  width="640"
-                  height="360"
-                />
-                <div class="flex flex-1 flex-col gap-2 p-4">
-                  <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-neutral-600">
-                    <span>Impact {post.data.impact_score}</span>
-                    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
-                    <span>{formatDate(post.data.date)}</span>
-                  </div>
-                  <h3 class="text-base font-semibold text-neutral-900">{post.data.title}</h3>
-                  <p class="text-sm text-neutral-700">{post.data.description}</p>
-                </div>
-              </a>
+              <PostCard post={post} />
             ))}
           </div>
         </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,3 +21,17 @@ a {
 a:hover {
   color: var(--accent);
 }
+
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -35,20 +35,18 @@
 }
 
 .prose {
-  @apply mx-auto max-w-none leading-7 sm:leading-8 prose-headings:tracking-tight prose-headings:font-semibold;
-  @apply prose-neutral dark:prose-invert;
-  @apply prose-h1:text-3xl prose-h1:sm:text-4xl prose-h1:font-extrabold;
-  @apply prose-h2:text-2xl prose-h2:sm:text-3xl prose-h2:font-bold;
-  @apply prose-h3:text-xl prose-h3:sm:text-2xl prose-h3:font-semibold;
+  @apply mx-auto max-w-3xl leading-7 sm:leading-8 prose-headings:tracking-tight prose-headings:font-semibold prose-headings:mt-8 prose-headings:mb-4;
+  @apply prose-neutral;
+  @apply prose-h1:text-4xl prose-h1:sm:text-5xl prose-h1:font-extrabold;
+  @apply prose-h2:text-3xl prose-h2:sm:text-4xl prose-h2:font-bold;
+  @apply prose-h3:text-2xl prose-h3:sm:text-3xl prose-h3:font-semibold;
   @apply prose-p:text-base prose-p:sm:text-lg;
-  @apply prose-a:no-underline hover:prose-a:underline;
-  @apply prose-img:rounded-2xl prose-img:border prose-img:border-neutral-200 dark:prose-img:border-neutral-800;
-  @apply prose-code:px-2 prose-code:py-1 prose-code:rounded-md prose-code:bg-neutral-100 prose-code:text-neutral-900 dark:prose-code:bg-neutral-900 dark:prose-code:text-neutral-100;
+  @apply prose-a:no-underline hover:prose-a:underline prose-a:underline-offset-2;
+  @apply prose-img:rounded-2xl prose-img:border prose-img:border-neutral-200;
+  @apply prose-code:px-2 prose-code:py-1 prose-code:rounded-md prose-code:bg-neutral-100 prose-code:text-neutral-900;
   @apply prose-pre:rounded-2xl prose-pre:p-5 prose-pre:bg-neutral-50 prose-pre:text-neutral-900 prose-pre:border prose-pre:border-neutral-200;
-  @apply dark:prose-pre:bg-neutral-900 dark:prose-pre:text-neutral-100 dark:prose-pre:border-neutral-800;
-  @apply prose-hr:border-neutral-200 dark:prose-hr:border-neutral-800;
-  @apply prose-blockquote:border-l-4 prose-blockquote:border-neutral-200 prose-blockquote:text-neutral-600;
-  @apply dark:prose-blockquote:border-neutral-700 dark:prose-blockquote:text-neutral-400;
+  @apply prose-hr:border-neutral-200;
+  @apply prose-blockquote:border-l-4 prose-blockquote:border-neutral-200 prose-blockquote:text-neutral-600 prose-blockquote:pl-5;
 }
 
 .prose table {


### PR DESCRIPTION
Notes:
- Key files touched: `src/layouts/BaseLayout.astro`, `src/layouts/PostLayout.astro`, `src/components/Navbar.astro`, `src/components/PostCard.astro`, `src/components/BlogList.astro`, `src/components/PostGrid.astro`, `src/pages/index.astro`, `src/styles/tailwind.css`, `src/styles/global.css`.
- Global theme applied/locked in `BaseLayout.astro` and `PostLayout.astro` (removed page-level dark toggles and dark classes).
- Grid column behavior controlled in `src/pages/index.astro`, `src/components/BlogList.astro`, and `src/components/PostGrid.astro`.
- Post card component lives at `src/components/PostCard.astro` and is now reused across listing pages.

### Motivation
- Ensure a single, consistent light theme site-wide by removing page-level dark-mode toggles and dark background classes.
- Fix inconsistent listing layouts so post listings render a stable grid of 1/2/3 columns across breakpoints.
- Normalize the post card UI to a single component with consistent spacing, borders, typography, and hover states.
- Lock post imagery to a single aspect ratio (16:9) and apply small typography rhythm improvements for better readability.

### Description
- Locked global light theme by removing client-side theme toggles and `dark:*` page classes and enforcing `bg-white text-neutral-900` on the main layouts (`BaseLayout`, `PostLayout`).
- Normalized listing grids to stable classes `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` in `index.astro`, `BlogList.astro`, and `PostGrid.astro` to avoid mixed 4/3 column rows.
- Introduced/standardized `PostCard` (`src/components/PostCard.astro`) used by homepage, archive, and grid components, adding consistent padding, subtle border, hover lift, clamped titles/excerpts, and metadata layout.
- Enforced 16:9 imagery by wrapping hero/thumb images in `aspect-[16/9]` containers and using `object-cover`, added `line-clamp-2`/`line-clamp-3` utilities to `global.css`, and refined prose rules in `src/styles/tailwind.css` for improved typography rhythm.

### Testing
- Attempted `npm install` and dependency install failed due to outbound registry access blocked by a proxy (HTTP 403), preventing running further automated commands.
- `npm test` (Playwright) was not executed because dependencies could not be installed, so automated tests were not run.
- `npm run build` was not executed for the same reason (install/build blocked by proxy), so build verification is pending.
- Created and verified Git changes locally via commits and diffs; visual/local dev verification remained blocked by the environment's proxy restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cb2e2517c8326ac69ee2ae0d03562)