### PR TITLE
Add build fingerprint (Vercel commit + env meta + footer)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,8 @@
 ---
 // Footer.astro — Wrappixel-inspired, as described in SETUP.md
+import type { BuildFingerprint } from '../utils/buildFingerprint';
+
+const { fingerprint } = Astro.props as { fingerprint: BuildFingerprint };
 ---
 <footer class="w-full bg-gray-50 border-t border-gray-200 py-6 mt-12 text-sm">
   <div class="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between px-4 gap-2">
@@ -14,5 +17,8 @@
       <a href="/privacy" class="hover:text-blue-600 transition">Privacy</a>
       <a href="/terms" class="hover:text-blue-600 transition">Terms</a>
     </nav>
+  </div>
+  <div class="max-w-7xl mx-auto px-4 pt-3 text-xs text-gray-400">
+    {fingerprint.displayLabel}
   </div>
 </footer>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import Navbar from '../components/Navbar.astro';
 import Footer from '../components/Footer.astro';
 import '../styles/global.css';
 import { warnIfAnalyticsMissing } from '../utils/env.server';
+import { getBuildFingerprint } from '../utils/buildFingerprint';
 
 const {
   title = 'Survive the AI',
@@ -14,6 +15,7 @@ const {
 
 const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
 const analyticsDebug = import.meta.env.PUBLIC_ANALYTICS_DEBUG === 'true';
+const fingerprint = getBuildFingerprint();
 
 warnIfAnalyticsMissing();
 ---
@@ -24,6 +26,7 @@ warnIfAnalyticsMissing();
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <meta name="build" content={fingerprint.metaContent} />
     <title>{title}</title>
     {gaMeasurementId && (
       <>
@@ -44,7 +47,7 @@ warnIfAnalyticsMissing();
     <main class="min-h-screen">
       <slot />
     </main>
-    <Footer />
+    <Footer fingerprint={fingerprint} />
     <script is:inline>
       {`
         (function() {

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -15,6 +15,8 @@ import { TOPIC_CATEGORIES } from '../data/categories';
 import SubscribeInline from '../components/SubscribeInline';
 import { buildPostLinking } from '../utils/postLinking';
 import { getHubByKey } from '../data/hubs';
+import Footer from '../components/Footer.astro';
+import { getBuildFingerprint } from '../utils/buildFingerprint';
 
 const {
   post,
@@ -48,6 +50,7 @@ const hubPath = hub?.slug ? `${hub.slug}/` : undefined;
 const hubLabel = hub?.shortName ?? (linking.pillar ? categoryByKey.get(linking.pillar)?.label : undefined);
 const analyticsDebug = import.meta.env.PUBLIC_ANALYTICS_DEBUG === 'true';
 const hasGa = Boolean(import.meta.env.PUBLIC_GA_MEASUREMENT_ID);
+const fingerprint = getBuildFingerprint();
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -86,6 +89,7 @@ const structuredData = {
     <meta name="twitter:title" content={title} />
     {description && <meta name="twitter:description" content={description} />}
     <meta name="twitter:image" content={heroSrc.startsWith('http') ? heroSrc : new URL(heroSrc, canonicalUrl).toString()} />
+    <meta name="build" content={fingerprint.metaContent} />
     <title>{title} · Survive the AI</title>
     <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
   </head>
@@ -205,6 +209,7 @@ const structuredData = {
         </aside>
       </div>
     </div>
+    <Footer fingerprint={fingerprint} />
     <script is:inline>
       {`
         (function() {

--- a/src/utils/buildFingerprint.ts
+++ b/src/utils/buildFingerprint.ts
@@ -1,0 +1,38 @@
+export type BuildFingerprint = {
+  displayLabel: string;
+  metaContent: string;
+  shortSha: string | null;
+  environment: string | null;
+  deploymentId: string | null;
+  commitRef: string | null;
+};
+
+export function getBuildFingerprint(): BuildFingerprint {
+  const commitSha = import.meta.env.VERCEL_GIT_COMMIT_SHA as string | undefined;
+  const environment = import.meta.env.VERCEL_ENV as string | undefined;
+  const deploymentId = import.meta.env.VERCEL_DEPLOYMENT_ID as string | undefined;
+  const commitRef = import.meta.env.VERCEL_GIT_COMMIT_REF as string | undefined;
+
+  if (!commitSha) {
+    return {
+      displayLabel: 'Build: local',
+      metaContent: 'local',
+      shortSha: null,
+      environment: null,
+      deploymentId: deploymentId ?? null,
+      commitRef: commitRef ?? null,
+    };
+  }
+
+  const shortSha = commitSha.slice(0, 7);
+  const envLabel = environment ?? 'unknown';
+
+  return {
+    displayLabel: `Build ${shortSha} · ${envLabel}`,
+    metaContent: `${shortSha}|${envLabel}`,
+    shortSha,
+    environment: envLabel,
+    deploymentId: deploymentId ?? null,
+    commitRef: commitRef ?? null,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, permanent build fingerprint so the site can be quickly verified against the deployed production build.
- Surface Vercel build information (commit SHA, deployment env) in both a subtle visible footer and a non-visual meta tag for programmatic verification.
- Gracefully fallback to a local indicator when Vercel environment variables are unavailable to avoid build/hydration issues.

### Description
- Added `src/utils/buildFingerprint.ts` with `getBuildFingerprint()` to read `VERCEL_GIT_COMMIT_SHA`, `VERCEL_ENV`, `VERCEL_DEPLOYMENT_ID`, and `VERCEL_GIT_COMMIT_REF`, returning a short 7-char SHA and `Build: local` fallback.
- Injected a meta tag `meta name="build" content="<short-sha>|<vercel-env>"` into `BaseLayout.astro` and `PostLayout.astro` using `getBuildFingerprint()` for non-visual verification.
- Passed the fingerprint into `Footer.astro` and rendered a low-contrast, small line showing the build (class `text-xs text-gray-400`) so it appears on all pages without changing layout hierarchy.
- All changes avoid new dependencies and use only `import.meta.env` to read environment variables so builds remain safe when vars are missing.

### Testing
- Attempted `npm run build` which failed in this environment because the Astro CLI/binaries were not available (installation issues in the sandbox), so a full site build could not be completed.
- Attempted dependency install (`npm ci`, `npm ci --ignore-scripts`) but the install process stalled/produced warnings in this environment and did not finish, preventing successful automated build validation.
- Unit or integration tests were not added or run as part of this PR; no Playwright tests were executed due to the incomplete install/build step.
- Manual code inspection and local SSR-safe patterns were applied to ensure no SSR-only APIs or secrets were exposed and the fingerprint falls back to `Build: local` when vars are missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9eefb39c8326b130e71e9c0740fc)