### PR TITLE
Add Supabase + Resend newsletter signup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "@astrojs/react": "^3.0.0",
+    "@supabase/supabase-js": "^2.56.0",
     "astro": "^5.12.3",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "resend": "^4.0.0"
   },
   "devDependencies": {
     "@astrojs/tailwind": "^6.0.2",

--- a/src/components/SubscribeInline.tsx
+++ b/src/components/SubscribeInline.tsx
@@ -70,7 +70,7 @@ export default function SubscribeInline({
     const form = event.currentTarget;
     const formData = new FormData(form);
     const email = (formData.get('email') as string | null)?.trim();
-    const honeypot = (formData.get('organization') as string | null)?.trim();
+    const honeypot = (formData.get('company') as string | null)?.trim();
 
     if (status === 'disabled' || !enabled) {
       setStatus('disabled');
@@ -106,11 +106,11 @@ export default function SubscribeInline({
       const response = await fetch('/api/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, source: location, honeypot }),
+        body: JSON.stringify({ email, source_page: location, company: honeypot }),
       });
-      const data = (await response.json().catch(() => ({}))) as { message?: string; mode?: string };
+      const data = (await response.json().catch(() => ({}))) as { ok?: boolean; message?: string; mode?: string };
 
-      if (!response.ok) {
+      if (!response.ok || data.ok === false) {
         throw new Error(data?.message || 'Unable to subscribe right now.');
       }
 
@@ -138,7 +138,7 @@ export default function SubscribeInline({
       </div>
 
       <form className="mt-6 space-y-4" onSubmit={onSubmit}>
-        <input type="text" name="organization" tabIndex={-1} autoComplete="off" className="hidden" aria-hidden="true" />
+        <input type="text" name="company" tabIndex={-1} autoComplete="off" className="hidden" aria-hidden="true" />
         <div className="flex flex-col gap-3 sm:flex-row">
           <div className="flex-1 space-y-2">
             <label htmlFor={`email-${location}`} className="text-sm font-semibold text-neutral-800">

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -1,25 +1,29 @@
 import type { APIRoute } from 'astro';
+import { createClient } from '@supabase/supabase-js';
+import { Resend } from 'resend';
 import { getSubscribeConfig } from '../../utils/env.server';
 
 export const prerender = false;
 
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
 const BAD_REQUEST = (message: string) =>
-  new Response(JSON.stringify({ message, error: 'bad_request' }), {
+  new Response(JSON.stringify({ ok: false, message, error: 'bad_request' }), {
     status: 400,
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
   });
 
 const SERVICE_UNAVAILABLE = (message: string, code = 'disabled') =>
-  new Response(JSON.stringify({ message, error: code }), {
+  new Response(JSON.stringify({ ok: false, message, error: code }), {
     status: 503,
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
   });
 
 export const GET: APIRoute = () => {
   const config = getSubscribeConfig();
   return new Response(JSON.stringify({ status: 'ready', mode: config.mode, enabled: config.enabled, hasCredentials: config.hasCredentials }), {
     status: 200,
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
   });
 };
 
@@ -30,17 +34,19 @@ export const POST: APIRoute = async ({ request }) => {
     return BAD_REQUEST('Invalid request.');
   }
 
-  const { email, source, honeypot } = (await request.json().catch(() => ({}))) as {
+  const { email, source_page, source, company } = (await request.json().catch(() => ({}))) as {
     email?: string;
+    source_page?: string;
     source?: string;
-    honeypot?: string;
+    company?: string;
   };
 
-  if (honeypot) {
-    return new Response(JSON.stringify({ status: 'ignored' }), { status: 200 });
+  if (company) {
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers: JSON_HEADERS });
   }
 
-  if (!email || !email.includes('@') || email.length > 150) {
+  const normalizedEmail = email?.trim().toLowerCase();
+  if (!normalizedEmail || !normalizedEmail.includes('@') || normalizedEmail.length > 254) {
     return BAD_REQUEST('Add a valid email to subscribe.');
   }
 
@@ -49,61 +55,77 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   if (config.mode === 'log-only') {
-    console.info(`[newsletter][log-only] ${email}`, { source: source ?? 'inline' });
-    return new Response(
-      JSON.stringify({
-        status: 'pending',
-        message: 'Saved (dev mode). Newsletter will go live soon.',
-        mode: 'log-only',
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
-    );
-  }
-
-  if (!config.hasCredentials || !config.buttondownKey) {
-    console.error('[newsletter] BUTTONDOWN_API_KEY missing while PUBLIC_ENABLE_SUBSCRIBE_API=true');
-    return new Response(JSON.stringify({ message: 'Signup temporarily unavailable. Please try again later.', error: 'missing_credentials' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    console.info(`[newsletter][log-only] ${normalizedEmail}`, { source_page: source_page ?? source ?? 'inline' });
+    return new Response(JSON.stringify({ ok: true, mode: 'log-only' }), { status: 200, headers: JSON_HEADERS });
   }
 
   try {
-    const response = await fetch('https://api.buttondown.email/v1/subscribers', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Token ${config.buttondownKey}`,
-      },
-      body: JSON.stringify({
-        email,
-        notes: `Source: ${source ?? 'inline'}`,
-        publication_id: config.publicationId || undefined,
-      }),
-    });
+    const supabaseUrl = import.meta.env.SUPABASE_URL;
+    const supabaseKey = import.meta.env.SUPABASE_SERVICE_ROLE_KEY ?? import.meta.env.SUPABASE_ANON_KEY;
+    const resendKey = import.meta.env.RESEND_API_KEY;
+    const resendFrom = import.meta.env.RESEND_FROM;
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(`[newsletter][buttondown] error`, errorText);
-      return new Response(
-        JSON.stringify({ message: 'Unable to subscribe right now. Please try again later.', error: 'provider_error' }),
-        { status: 502, headers: { 'Content-Type': 'application/json' } },
-      );
+    if (!supabaseUrl || !supabaseKey) {
+      console.error('[newsletter] Supabase credentials missing.');
+      return new Response(JSON.stringify({ ok: false, message: 'Signup temporarily unavailable. Please try again later.' }), {
+        status: 500,
+        headers: JSON_HEADERS,
+      });
     }
 
-    return new Response(
-      JSON.stringify({
-        status: 'subscribed',
-        message: 'Check your inbox to confirm your subscription.',
-        mode: 'provider',
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    if (!resendKey || !resendFrom) {
+      console.error('[newsletter] Resend credentials missing.');
+      return new Response(JSON.stringify({ ok: false, message: 'Signup temporarily unavailable. Please try again later.' }), {
+        status: 500,
+        headers: JSON_HEADERS,
+      });
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey, {
+      auth: { persistSession: false },
+    });
+
+    const { error } = await supabase.from('subscribers').upsert(
+      {
+        email: normalizedEmail,
+        source_page: source_page ?? source ?? null,
+      },
+      { onConflict: 'email' },
     );
+
+    if (error) {
+      console.error('[newsletter] Supabase upsert failed', error);
+      return new Response(JSON.stringify({ ok: false, message: 'Unable to subscribe right now. Please try again later.' }), {
+        status: 500,
+        headers: JSON_HEADERS,
+      });
+    }
+
+    const resend = new Resend(resendKey);
+    const origin = new URL('/', request.url).origin;
+    const subject = import.meta.env.RESEND_WELCOME_SUBJECT ?? 'Welcome to Survive the AI';
+    const text = `You're in.\n\nExpect weekly survival intel—practical moves to protect your work, family, and focus.\n\nVisit: ${origin}\n\nUnsubscribe anytime via your email provider.`;
+    const { error: resendError } = await resend.emails.send({
+      from: resendFrom,
+      to: normalizedEmail,
+      subject,
+      text,
+    });
+
+    if (resendError) {
+      console.error('[newsletter] Resend error', resendError);
+      return new Response(JSON.stringify({ ok: false, message: 'Unable to subscribe right now. Please try again later.' }), {
+        status: 500,
+        headers: JSON_HEADERS,
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers: JSON_HEADERS });
   } catch (error) {
     console.error('[newsletter] unexpected error', error);
-    return new Response(
-      JSON.stringify({ message: 'Something went wrong. Try again in a bit.', error: 'unexpected_error' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } },
-    );
+    return new Response(JSON.stringify({ ok: false, message: 'Something went wrong. Try again in a bit.', error: 'unexpected_error' }), {
+      status: 500,
+      headers: JSON_HEADERS,
+    });
   }
 };

--- a/src/utils/env.server.ts
+++ b/src/utils/env.server.ts
@@ -2,8 +2,6 @@ type SubscribeMode = 'disabled' | 'log-only' | 'provider';
 
 type SubscribeConfig = {
   mode: SubscribeMode;
-  buttondownKey?: string;
-  publicationId?: string;
   enabled: boolean;
   hasCredentials: boolean;
 };
@@ -13,9 +11,11 @@ let hasWarnedSubscribe = false;
 export function getSubscribeConfig(): SubscribeConfig {
   const enabled = import.meta.env.PUBLIC_ENABLE_SUBSCRIBE_API === 'true';
   const logOnly = import.meta.env.SUBSCRIBE_LOG_ONLY === 'true';
-  const buttondownKey = import.meta.env.BUTTONDOWN_API_KEY;
-  const publicationId = import.meta.env.BUTTONDOWN_PUBLICATION_ID;
-  const hasCredentials = Boolean(buttondownKey);
+  const supabaseUrl = import.meta.env.SUPABASE_URL;
+  const supabaseKey = import.meta.env.SUPABASE_SERVICE_ROLE_KEY ?? import.meta.env.SUPABASE_ANON_KEY;
+  const resendKey = import.meta.env.RESEND_API_KEY;
+  const resendFrom = import.meta.env.RESEND_FROM;
+  const hasCredentials = Boolean(supabaseUrl && supabaseKey && resendKey && resendFrom);
 
   let mode: SubscribeMode = 'disabled';
   if (enabled && logOnly) {
@@ -25,10 +25,8 @@ export function getSubscribeConfig(): SubscribeConfig {
   }
 
   if (!hasWarnedSubscribe) {
-    if (enabled && !buttondownKey && !logOnly) {
-      console.warn(
-        '[config][subscribe] PUBLIC_ENABLE_SUBSCRIBE_API is true but BUTTONDOWN_API_KEY is missing. Endpoint will return 500 until credentials are set.',
-      );
+    if (enabled && !hasCredentials && !logOnly) {
+      console.warn('[config][subscribe] PUBLIC_ENABLE_SUBSCRIBE_API is true but credentials are missing. Endpoint will return 500 until credentials are set.');
     }
     if (!enabled && logOnly) {
       console.warn('[config][subscribe] SUBSCRIBE_LOG_ONLY is true but subscribe API is disabled. Requests will be rejected.');
@@ -36,7 +34,7 @@ export function getSubscribeConfig(): SubscribeConfig {
     hasWarnedSubscribe = true;
   }
 
-  return { mode, buttondownKey, publicationId, enabled, hasCredentials };
+  return { mode, enabled, hasCredentials };
 }
 
 let hasWarnedAnalytics = false;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,8 @@
+create extension if not exists pgcrypto;
+
+create table if not exists subscribers (
+  id uuid primary key default gen_random_uuid(),
+  email text not null unique,
+  source_page text,
+  created_at timestamptz not null default now()
+);


### PR DESCRIPTION
### Motivation
- Replace the existing Buttondown-backed newsletter flow with a Supabase-backed subscriber store and Resend for welcome emails to provide a server-side, production-safe signup flow.  
- Keep credentials strictly server-side and avoid exposing service keys to the browser.  
- Provide a simple anti-bot honeypot and normalize inputs so the endpoint can be safely called from the existing frontend.  
- Return consistent, minimal JSON responses for the frontend to consume.

### Description
- Added dependency entries for `@supabase/supabase-js` and `resend` in `package.json` and added a DB schema at `supabase/schema.sql` that creates `subscribers` with `gen_random_uuid()` and timestamps.  
- Reworked `src/pages/api/subscribe.ts` to validate and normalize `email`, ignore submissions with the `company` honeypot, upsert into Supabase using `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (fallback to anon), send a welcome email via `RESEND_API_KEY`/`RESEND_FROM`, and return clean `{ ok: true/false }` JSON responses.  
- Updated `src/utils/env.server.ts` to surface whether server credentials are present and to drive the API `mode`, and added checks for required env vars.  
- Wired the frontend `src/components/SubscribeInline.tsx` to post `company` (honeypot) and `source_page`, handle the new JSON shape, and keep UX unchanged otherwise.

### Testing
- No automated tests were executed in this environment.  
- Attempted `npm install @supabase/supabase-js resend` but the registry returned `403` so dependencies could not be installed and `package-lock.json` was not updated.  
- Existing Playwright tests were not run as part of this change.  
- Server-side logging was left in place for errors to aid debugging during deployment and integration testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69643808949c8326b1808b76f2ccb952)