### PR TITLE
Update subscribe API to use Supabase + Resend

### DIFF
--- a/src/utils/env.server.ts
+++ b/src/utils/env.server.ts
@@ -1,7 +1,4 @@
-type SubscribeMode = 'disabled' | 'log-only' | 'provider';
-
 type SubscribeConfig = {
-  mode: SubscribeMode;
   enabled: boolean;
   hasCredentials: boolean;
 };
@@ -10,31 +7,20 @@ let hasWarnedSubscribe = false;
 
 export function getSubscribeConfig(): SubscribeConfig {
   const enabled = import.meta.env.PUBLIC_ENABLE_SUBSCRIBE_API === 'true';
-  const logOnly = import.meta.env.SUBSCRIBE_LOG_ONLY === 'true';
   const supabaseUrl = import.meta.env.SUPABASE_URL;
   const supabaseKey = import.meta.env.SUPABASE_SERVICE_ROLE_KEY ?? import.meta.env.SUPABASE_ANON_KEY;
   const resendKey = import.meta.env.RESEND_API_KEY;
   const resendFrom = import.meta.env.RESEND_FROM;
   const hasCredentials = Boolean(supabaseUrl && supabaseKey && resendKey && resendFrom);
 
-  let mode: SubscribeMode = 'disabled';
-  if (enabled && logOnly) {
-    mode = 'log-only';
-  } else if (enabled) {
-    mode = 'provider';
-  }
-
   if (!hasWarnedSubscribe) {
-    if (enabled && !hasCredentials && !logOnly) {
+    if (enabled && !hasCredentials) {
       console.warn('[config][subscribe] PUBLIC_ENABLE_SUBSCRIBE_API is true but credentials are missing. Endpoint will return 500 until credentials are set.');
-    }
-    if (!enabled && logOnly) {
-      console.warn('[config][subscribe] SUBSCRIBE_LOG_ONLY is true but subscribe API is disabled. Requests will be rejected.');
     }
     hasWarnedSubscribe = true;
   }
 
-  return { mode, enabled, hasCredentials };
+  return { enabled, hasCredentials };
 }
 
 let hasWarnedAnalytics = false;


### PR DESCRIPTION
### Motivation
- Replace Buttondown integration with Supabase (for storing subscribers) and Resend (for welcome emails) and gate signups behind `PUBLIC_ENABLE_SUBSCRIBE_API`.
- Preserve existing honeypot and basic email validation to reduce spam and avoid exposing whether a subscriber already existed.
- Provide a GET status that reports whether the subscribe API is enabled and has required credentials.

### Description
- Reworked `src/pages/api/subscribe.ts` to upsert normalized (trimmed, lowercased) emails into the `public.subscribers` Supabase table using `@supabase/supabase-js` and to send a plaintext welcome email via `resend` with the subject "You're on the Survive the AI list" and the required body text.
- Kept the honeypot behavior returning `200 {status: 'ignored'}` when the `company` field is present and retained basic email format/length validation, returning `400` on invalid input.
- Enforced `PUBLIC_ENABLE_SUBSCRIBE_API === 'true'` via `getSubscribeConfig()` before allowing signups and updated GET to return `{ status: 'ready'|'needs_config', enabled, hasCredentials }` to reflect Supabase/Resend readiness.
- Simplified `src/utils/env.server.ts` (`getSubscribeConfig`) to return only `enabled` and `hasCredentials` flags and removed the previous log-only mode handling.
- Implemented server-side logging for Supabase/Resend errors and return generic `500` or `502` responses to the client without leaking sensitive details.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671d3f8a548326b2e2468b297002ce)