### PR TITLE
[codex] Refactor homepage into editorial pressure board

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1774393765187
+		"lastUpdateCheck": 1776208970744
 	}
 }

--- a/src/components/homepage/CommunityVote.astro
+++ b/src/components/homepage/CommunityVote.astro
@@ -1,0 +1,89 @@
+---
+import type { HomepageVoteOption } from '../../data/homepageBoard';
+
+const { prompt, options } = Astro.props as {
+  prompt: string;
+  options: HomepageVoteOption[];
+};
+---
+
+<section class="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-vote" data-vote-widget>
+  <div class="space-y-1">
+    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Community vote</p>
+    <h3 class="text-xl font-black text-white">{prompt}</h3>
+    <p class="text-sm leading-relaxed text-neutral-400">
+      Local browser vote for now. This widget stores only your selection on this device until a sitewide API exists.
+    </p>
+  </div>
+
+  <div class="mt-5 grid gap-3">
+    {options.map((option) => (
+      <button
+        type="button"
+        class="vote-option flex items-start justify-between gap-4 rounded-2xl border border-white/10 bg-black/10 px-4 py-3 text-left transition hover:border-white/20 hover:bg-white/[0.07]"
+        data-vote-option
+        data-option-id={option.id}
+      >
+        <span class="space-y-1">
+          <span class="block text-sm font-semibold text-white">{option.label}</span>
+          <span class="block text-sm leading-relaxed text-neutral-400">{option.description}</span>
+        </span>
+        <span class="vote-pill mt-0.5 rounded-full border border-white/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">
+          Vote
+        </span>
+      </button>
+    ))}
+  </div>
+
+  <p class="mt-4 text-sm font-semibold text-neutral-300" data-vote-status>Choose one fear area to save your local vote.</p>
+</section>
+
+<script is:inline>
+  (() => {
+    const widget = document.querySelector('[data-vote-widget]');
+    if (!(widget instanceof HTMLElement)) return;
+
+    const buttons = Array.from(widget.querySelectorAll('[data-vote-option]'));
+    const status = widget.querySelector('[data-vote-status]');
+    const storageKey = 'sta-homepage-pressure-vote';
+
+    const render = (selectedId) => {
+      buttons.forEach((button) => {
+        if (!(button instanceof HTMLElement)) return;
+        const active = button.dataset.optionId === selectedId;
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+        button.classList.toggle('border-white/40', active);
+        button.classList.toggle('bg-white/[0.08]', active);
+        const pill = button.querySelector('.vote-pill');
+        if (pill instanceof HTMLElement) {
+          pill.textContent = active ? 'Saved' : 'Vote';
+          pill.classList.toggle('text-white', active);
+          pill.classList.toggle('border-white/30', active);
+        }
+      });
+
+      if (status instanceof HTMLElement) {
+        if (!selectedId) {
+          status.textContent = 'Choose one fear area to save your local vote.';
+          return;
+        }
+
+        const selected = buttons.find((button) => button instanceof HTMLElement && button.dataset.optionId === selectedId);
+        const label = selected?.querySelector('span > span');
+        status.textContent = label instanceof HTMLElement ? `Local vote saved: ${label.textContent}.` : 'Local vote saved.';
+      }
+    };
+
+    const initial = window.localStorage.getItem(storageKey) ?? '';
+    render(initial);
+
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        if (!(button instanceof HTMLElement)) return;
+        const next = button.dataset.optionId ?? '';
+        window.localStorage.setItem(storageKey, next);
+        render(next);
+      });
+    });
+  })();
+</script>

--- a/src/components/homepage/ImpactScoreFeed.astro
+++ b/src/components/homepage/ImpactScoreFeed.astro
@@ -1,0 +1,51 @@
+---
+import type { PostEntry } from '../../content/config';
+import { TOPIC_CATEGORIES } from '../../data/categories';
+import { formatDate } from '../../utils/format';
+
+const { items } = Astro.props as { items: PostEntry[] };
+
+const categoryByKey = new Map(TOPIC_CATEGORIES.map((category) => [category.key, category]));
+---
+
+<section class="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-impact-feed">
+  <div class="flex items-end justify-between gap-4">
+    <div class="space-y-1">
+      <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Latest impact score items</p>
+      <h3 class="text-xl font-black text-white">Route into the newest reporting</h3>
+    </div>
+    <a href="/posts" class="text-sm font-semibold text-neutral-200 underline decoration-white/20 underline-offset-4 transition hover:text-white">
+      Full archive
+    </a>
+  </div>
+
+  <div class="mt-5 space-y-3">
+    {items.map((post) => {
+      const category = post.data.topics?.[0] ? categoryByKey.get(post.data.topics[0]) : undefined;
+
+      return (
+        <a
+          href={`/posts/${post.slug}/`}
+          class="flex flex-col gap-4 rounded-2xl border border-white/10 bg-black/10 p-4 transition hover:border-white/20 hover:bg-white/[0.07] sm:flex-row sm:items-center sm:justify-between"
+          data-testid="pressure-room-impact-item"
+        >
+          <div class="space-y-2">
+            <div class="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-400">
+              <span>{category?.label ?? post.data.category ?? 'Key topic'}</span>
+              <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-600" />
+              <span>{formatDate(post.data.date)}</span>
+            </div>
+            <h4 class="text-base font-bold leading-tight text-white">{post.data.title}</h4>
+            <p class="text-sm leading-relaxed text-neutral-400">{post.data.description}</p>
+          </div>
+          <div class="flex flex-none items-center gap-3 sm:flex-col sm:items-end">
+            <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-200">
+              Impact {post.data.impact_score}
+            </span>
+            <span class="text-sm font-semibold text-neutral-200">Read post</span>
+          </div>
+        </a>
+      );
+    })}
+  </div>
+</section>

--- a/src/components/homepage/LeadDispatchCard.astro
+++ b/src/components/homepage/LeadDispatchCard.astro
@@ -1,0 +1,66 @@
+---
+import type { PostEntry } from '../../content/config';
+import { getAuthorProfile } from '../../data/authors';
+import { formatDate } from '../../utils/format';
+
+const { post } = Astro.props as { post?: PostEntry };
+
+const author = post ? getAuthorProfile(post.data.author) : undefined;
+---
+
+<section class="overflow-hidden rounded-2xl border border-white/10 bg-white/5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-lead-story">
+  {post ? (
+    <>
+      <a href={`/posts/${post.slug}/`} class="block">
+        <div class="relative aspect-[16/9] overflow-hidden bg-neutral-900">
+          <img
+            src={post.data.heroImage}
+            alt={post.data.heroImageAlt ?? post.data.title}
+            loading="lazy"
+            decoding="async"
+            width="1200"
+            height="630"
+            class="h-full w-full object-cover"
+          />
+          <div class="absolute inset-0 bg-gradient-to-t from-black via-black/35 to-transparent"></div>
+        </div>
+      </a>
+      <div class="space-y-4 p-5">
+        <div class="space-y-2">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Lead dispatch</p>
+          <h3 class="text-2xl font-black tracking-tight text-white">{post.data.title}</h3>
+          <p class="text-sm leading-relaxed text-neutral-300">{post.data.description}</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-500">
+          <span>{formatDate(post.data.date)}</span>
+          <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-700" />
+          <span>{`By ${author?.displayName}`}</span>
+          <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-700" />
+          <a href="/impact-score-methodology" class="text-neutral-300 underline decoration-white/20 underline-offset-4 transition hover:text-white">
+            Impact Score {post.data.impact_score}
+          </a>
+        </div>
+        <div class="flex flex-wrap gap-3 pt-1">
+          <a
+            href={`/posts/${post.slug}/`}
+            class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200"
+          >
+            Read the lead dispatch
+          </a>
+          <a
+            href="/posts"
+            class="inline-flex items-center justify-center rounded-full border border-white/15 px-5 py-3 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/5"
+          >
+            Browse the library
+          </a>
+        </div>
+      </div>
+    </>
+  ) : (
+    <div class="space-y-3 p-5">
+      <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Lead dispatch</p>
+      <h3 class="text-2xl font-black text-white">No lead dispatch yet</h3>
+      <p class="text-sm leading-relaxed text-neutral-400">Publish the next post to populate the board’s lead story slot.</p>
+    </div>
+  )}
+</section>

--- a/src/components/homepage/LiveInputModules.astro
+++ b/src/components/homepage/LiveInputModules.astro
@@ -1,0 +1,55 @@
+---
+import type { HomepageLiveModule } from '../../data/homepageBoard';
+
+const { modules } = Astro.props as { modules: HomepageLiveModule[] };
+
+const toneClasses: Record<HomepageLiveModule['tone'], string> = {
+  high: 'border-rose-500/40 bg-rose-500/10',
+  medium: 'border-amber-400/30 bg-amber-300/5',
+  low: 'border-emerald-400/20 bg-white/5',
+};
+---
+
+<section class="space-y-4" data-testid="pressure-room-live-modules">
+  <div class="flex items-end justify-between gap-4">
+    <div class="space-y-1">
+      <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Near-live inputs</p>
+      <h3 class="text-xl font-black text-white sm:text-2xl">What the board is seeing now</h3>
+    </div>
+    <p class="max-w-sm text-right text-xs leading-relaxed text-neutral-500">Framed honestly from recent STA publishing activity.</p>
+  </div>
+
+  <div class="grid gap-4 md:grid-cols-2">
+    {modules.map((module) => (
+      <article class={`rounded-2xl border p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)] ${toneClasses[module.tone]}`}>
+        <div class="space-y-3">
+          <div class="flex items-start justify-between gap-4">
+            <p class="max-w-[15rem] text-sm font-semibold uppercase tracking-[0.18em] text-neutral-200">{module.title}</p>
+            <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-neutral-300">
+              {module.value}
+            </span>
+          </div>
+          <div class="space-y-2">
+            <p class="text-base font-semibold text-white">{module.summary}</p>
+            <p class="text-sm leading-relaxed text-neutral-400">{module.detail}</p>
+          </div>
+          {module.items && module.items.length > 0 && (
+            <ul class="space-y-1.5">
+              {module.items.map((item) => (
+                <li class="text-sm text-neutral-300">{item}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div class="mt-4 flex items-center justify-between gap-4 border-t border-white/10 pt-4">
+          <p class="max-w-xs text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-500">{module.sourceLabel}</p>
+          {module.href && module.hrefLabel && (
+            <a href={module.href} class="text-sm font-semibold text-neutral-100 underline decoration-white/20 underline-offset-4 transition hover:text-white">
+              {module.hrefLabel}
+            </a>
+          )}
+        </div>
+      </article>
+    ))}
+  </div>
+</section>

--- a/src/components/homepage/MacroGauges.astro
+++ b/src/components/homepage/MacroGauges.astro
@@ -1,0 +1,35 @@
+---
+import type { HomepageMacroGauge } from '../../data/homepageBoard';
+
+const { gauges } = Astro.props as { gauges: HomepageMacroGauge[] };
+---
+
+<section class="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-macro-gauges">
+  <div class="space-y-1">
+    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Editorial macro gauges</p>
+    <h3 class="text-xl font-black text-white">How the board reads the bigger picture</h3>
+  </div>
+
+  <div class="mt-5 space-y-5">
+    {gauges.map((gauge) => (
+      <article class="space-y-2">
+        <div class="flex items-end justify-between gap-4">
+          <div class="space-y-1">
+            <h4 class="text-base font-bold text-white">{gauge.title}</h4>
+            <p class="text-sm leading-relaxed text-neutral-400">{gauge.summary}</p>
+          </div>
+          <span class="text-2xl font-black tracking-tight text-white">{gauge.value}</span>
+        </div>
+        <div class="h-2 rounded-full bg-white/10" aria-hidden="true">
+          <div class="h-2 rounded-full bg-gradient-to-r from-neutral-300 via-neutral-100 to-white" style={`width:${gauge.value}%`}></div>
+        </div>
+        <div class="flex items-start justify-between gap-4">
+          <p class="max-w-sm text-sm leading-relaxed text-neutral-500">{gauge.detail}</p>
+          <a href={gauge.href} class="text-sm font-semibold text-neutral-200 underline decoration-white/20 underline-offset-4 transition hover:text-white">
+            {gauge.hrefLabel}
+          </a>
+        </div>
+      </article>
+    ))}
+  </div>
+</section>

--- a/src/components/homepage/PressureRoom.astro
+++ b/src/components/homepage/PressureRoom.astro
@@ -1,0 +1,45 @@
+---
+import type { HomepageBoardModel } from '../../data/homepageBoard';
+import CommunityVote from './CommunityVote.astro';
+import ImpactScoreFeed from './ImpactScoreFeed.astro';
+import LeadDispatchCard from './LeadDispatchCard.astro';
+import LiveInputModules from './LiveInputModules.astro';
+import MacroGauges from './MacroGauges.astro';
+import ThreatCardsBoard from './ThreatCardsBoard.astro';
+
+const { board } = Astro.props as { board: HomepageBoardModel };
+---
+
+<section
+  class="rounded-[2rem] border border-neutral-800 bg-neutral-950 px-5 py-6 text-white shadow-[0_28px_90px_-40px_rgba(0,0,0,0.75)] sm:px-6 sm:py-7 lg:px-8 lg:py-8"
+  data-testid="pressure-room-section"
+>
+  <div class="flex flex-col gap-4 border-b border-white/10 pb-6 lg:flex-row lg:items-end lg:justify-between">
+    <div class="max-w-3xl space-y-2">
+      <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-400">AI Pressure Room</p>
+      <h2 class="text-3xl font-black tracking-tight text-white sm:text-[2.4rem]">An editorial board surface for where AI pressure is building.</h2>
+      <p class="text-base leading-relaxed text-neutral-300">
+        Near-live modules summarize fresh STA coverage. Threat cards and macro gauges are explicit editorial judgments. Every route still
+        leads back into posts, hubs, and methodology.
+      </p>
+    </div>
+    <div class="max-w-md rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm leading-relaxed text-neutral-300">
+      <p class="font-semibold text-white">Board timestamp: {board.anchorDateLabel}</p>
+      <p class="mt-1">This surface uses local config and recent publishing cadence first, so future API wiring has a clear seam.</p>
+    </div>
+  </div>
+
+  <div class="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+    <div class="space-y-6">
+      <LiveInputModules modules={board.liveModules} />
+      <ThreatCardsBoard cards={board.threatCards} />
+    </div>
+
+    <div class="space-y-6">
+      <LeadDispatchCard post={board.leadPost} />
+      <MacroGauges gauges={board.macroGauges} />
+      <ImpactScoreFeed items={board.impactItems} />
+      <CommunityVote prompt={board.votePrompt} options={board.voteOptions} />
+    </div>
+  </div>
+</section>

--- a/src/components/homepage/ThreatCardsBoard.astro
+++ b/src/components/homepage/ThreatCardsBoard.astro
@@ -1,0 +1,57 @@
+---
+import type { HomepageThreatCard } from '../../data/homepageBoard';
+
+const { cards } = Astro.props as { cards: HomepageThreatCard[] };
+---
+
+<section class="space-y-4" data-testid="pressure-room-threat-cards">
+  <div class="space-y-1">
+    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Editorial threat board</p>
+    <h3 class="text-xl font-black text-white sm:text-2xl">Fear-area scores and weekly deltas</h3>
+  </div>
+
+  <div class="grid gap-4 lg:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+    {cards.map((card) => (
+      <article class="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-threat-card">
+        <div class="flex items-start justify-between gap-4">
+          <div class="space-y-2">
+            <div class="flex items-center gap-3">
+              <span class="inline-block h-2.5 w-2.5 rounded-full" style={`background:${card.hub.color}`} aria-hidden="true" />
+              <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-400">Editorial score</p>
+            </div>
+            <h4 class="text-lg font-black text-white">{card.hub.shortName}</h4>
+          </div>
+          <div class="text-right">
+            <p class="text-3xl font-black tracking-tight text-white">{card.score}</p>
+            <p class={`text-xs font-semibold uppercase tracking-[0.18em] ${card.delta >= 0 ? 'text-amber-300' : 'text-emerald-300'}`}>
+              {card.delta >= 0 ? '+' : ''}
+              {card.delta} this week
+            </p>
+          </div>
+        </div>
+
+        <div class="mt-4 space-y-2">
+          <p class="text-sm font-semibold leading-relaxed text-neutral-100">{card.stance}</p>
+          <p class="text-sm leading-relaxed text-neutral-400">{card.summary}</p>
+        </div>
+
+        <div class="mt-5 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4">
+          <a
+            href={`${card.hub.slug}/`}
+            class="inline-flex items-center justify-center rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/5"
+          >
+            Open {card.hub.shortName}
+          </a>
+          {card.latestPost && (
+            <a
+              href={`/posts/${card.latestPost.slug}/`}
+              class="text-sm font-semibold text-neutral-200 underline decoration-white/20 underline-offset-4 transition hover:text-white"
+            >
+              Latest dispatch
+            </a>
+          )}
+        </div>
+      </article>
+    ))}
+  </div>
+</section>

--- a/src/data/homepageBoard.ts
+++ b/src/data/homepageBoard.ts
@@ -1,0 +1,266 @@
+import type { PostEntry } from '../content/config';
+import { formatDate } from '../utils/format';
+import { getPillarFromPost, type PillarKey } from '../utils/postLinking';
+import { isArchiveVisiblePost, isPlaceholderPost, sortPosts } from '../utils/postSections';
+import { buildHomepagePlacement } from './homepage';
+import { SURVIVAL_HUBS, type SurvivalHub } from './hubs';
+
+type LiveModuleTone = 'high' | 'medium' | 'low';
+
+export type HomepageLiveModule = {
+  title: string;
+  value: string;
+  summary: string;
+  detail: string;
+  sourceLabel: string;
+  tone: LiveModuleTone;
+  items?: string[];
+  href?: string;
+  hrefLabel?: string;
+};
+
+export type HomepageThreatCard = {
+  hub: SurvivalHub;
+  score: number;
+  delta: number;
+  stance: string;
+  summary: string;
+  latestPost?: PostEntry;
+};
+
+export type HomepageMacroGauge = {
+  title: string;
+  value: number;
+  summary: string;
+  detail: string;
+  href: string;
+  hrefLabel: string;
+};
+
+export type HomepageVoteOption = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+export type HomepageBoardModel = {
+  anchorDateLabel: string;
+  leadPost?: PostEntry;
+  liveModules: HomepageLiveModule[];
+  threatCards: HomepageThreatCard[];
+  macroGauges: HomepageMacroGauge[];
+  impactItems: PostEntry[];
+  votePrompt: string;
+  voteOptions: HomepageVoteOption[];
+};
+
+const EDITORIAL_THREAT_MODEL: Record<
+  PillarKey,
+  {
+    score: number;
+    delta: number;
+    stance: string;
+    summary: string;
+  }
+> = {
+  'work-money': {
+    score: 86,
+    delta: 6,
+    stance: 'Hiring freezes and invisible automation are moving faster than public layoff headlines.',
+    summary: 'Board editorial score. Work pressure is broad, quiet, and compounding.',
+  },
+  'kids-school': {
+    score: 74,
+    delta: 4,
+    stance: 'Schools still lag the tooling shift, so family policy is becoming the real first line of defense.',
+    summary: 'Board editorial score. Student integrity and durable skill-building are under steady pressure.',
+  },
+  'love-connection': {
+    score: 69,
+    delta: 5,
+    stance: 'Synthetic intimacy is normalizing faster than public literacy about manipulation, privacy, and habit loops.',
+    summary: 'Board editorial score. Emotional substitution risk is rising before norms catch up.',
+  },
+  'mind-attention': {
+    score: 78,
+    delta: 3,
+    stance: 'Cognitive offloading is becoming ambient infrastructure, not an opt-in productivity hack.',
+    summary: 'Board editorial score. Focus erosion is gradual, measurable, and easy to underestimate.',
+  },
+  'system-shock': {
+    score: 64,
+    delta: 2,
+    stance: 'Macro risk is still episodic, but resilience gaps remain larger than most households assume.',
+    summary: 'Board editorial score. Systemic shocks remain lower-frequency but high-consequence.',
+  },
+};
+
+const EDITORIAL_MACRO_GAUGES: HomepageMacroGauge[] = [
+  {
+    title: 'Household shock exposure',
+    value: 77,
+    summary: 'Editorial gauge of how directly ordinary households are feeling AI pressure right now.',
+    detail: 'Jobs, school routines, and attention systems are carrying the most immediate load.',
+    href: '/start-here',
+    hrefLabel: 'Open Start Here',
+  },
+  {
+    title: 'Institutional readiness',
+    value: 42,
+    summary: 'Editorial gauge of whether schools, employers, and policy systems look prepared.',
+    detail: 'Most institutions are still reacting piecemeal instead of designing around the new baseline.',
+    href: '/how-we-research',
+    hrefLabel: 'See the standards',
+  },
+  {
+    title: 'Synthetic trust distortion',
+    value: 71,
+    summary: 'Editorial gauge of how much AI is muddying what people can trust across media and relationships.',
+    detail: 'The deception layer is improving faster than household defenses and social norms.',
+    href: '/impact-score-methodology',
+    hrefLabel: 'Read the methodology',
+  },
+];
+
+const VOTE_OPTIONS: HomepageVoteOption[] = [
+  {
+    id: 'work-money',
+    label: 'Work & Money',
+    description: 'Job security, deskilling, layoffs, and income volatility feel closest to home.',
+  },
+  {
+    id: 'kids-school',
+    label: 'Kids & School',
+    description: 'Learning, honesty, and future-readiness for children feel most exposed.',
+  },
+  {
+    id: 'mind-attention',
+    label: 'Mind & Attention',
+    description: 'Focus, judgment, and independent thinking are taking the sharpest hit.',
+  },
+  {
+    id: 'love-connection',
+    label: 'Love & Connection',
+    description: 'Trust, intimacy, and loneliness feel most destabilized.',
+  },
+  {
+    id: 'system-shock',
+    label: 'System Shock',
+    description: 'Macro instability, deception, and institutional fragility feel hardest to ignore.',
+  },
+];
+
+const LIVE_SOURCE_LABEL = 'Near-live input. Derived from recently published STA coverage, not external live feeds.';
+
+function getHomepageEligiblePosts(posts: PostEntry[]) {
+  return sortPosts(posts).filter((post) => isArchiveVisiblePost(post) && !post.data.homepageHidden && !isPlaceholderPost(post));
+}
+
+function getPostsInWindow(posts: PostEntry[], anchorDate: Date, days: number) {
+  const millis = days * 24 * 60 * 60 * 1000;
+  return posts.filter((post) => anchorDate.getTime() - post.data.date.getTime() <= millis);
+}
+
+function average(values: number[]) {
+  if (!values.length) return 0;
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function clampScore(value: number) {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function buildTrendingAnxieties(posts: PostEntry[]) {
+  const counts = new Map<PillarKey, number>();
+
+  for (const post of posts) {
+    const pillar = getPillarFromPost(post);
+    if (!pillar) continue;
+    counts.set(pillar, (counts.get(pillar) ?? 0) + 1);
+  }
+
+  return [...SURVIVAL_HUBS]
+    .map((hub) => ({ hub, count: counts.get(hub.key) ?? 0 }))
+    .sort((a, b) => b.count - a.count || a.hub.order - b.hub.order)
+    .filter((item) => item.count > 0)
+    .slice(0, 3)
+    .map((item) => `${item.hub.shortName} (${item.count})`);
+}
+
+export function buildHomepageBoard(allPosts: PostEntry[]): HomepageBoardModel {
+  const eligiblePosts = getHomepageEligiblePosts(allPosts);
+  const placement = buildHomepagePlacement(allPosts);
+  const anchorDate = eligiblePosts[0]?.data.date ?? new Date();
+  const trailing14 = getPostsInWindow(eligiblePosts, anchorDate, 14);
+  const trailing30 = getPostsInWindow(eligiblePosts, anchorDate, 30);
+  const trailing45 = getPostsInWindow(eligiblePosts, anchorDate, 45);
+  const workMoney45 = trailing45.filter((post) => getPillarFromPost(post) === 'work-money');
+  const trendingAnxieties = buildTrendingAnxieties(trailing30);
+  const leadWorkMoney = workMoney45[0];
+  const fearHeat = clampScore(average(trailing30.map((post) => post.data.impact_score)));
+
+  const liveModules: HomepageLiveModule[] = [
+    {
+      title: 'AI fear heat / news volume',
+      value: `${fearHeat}/100`,
+      summary: 'Recent coverage intensity across the board.',
+      detail: `${trailing30.length} published signals in the trailing 30-day window ending ${formatDate(anchorDate)}.`,
+      sourceLabel: LIVE_SOURCE_LABEL,
+      tone: fearHeat >= 75 ? 'high' : fearHeat >= 55 ? 'medium' : 'low',
+      href: '/posts',
+      hrefLabel: 'View latest posts',
+    },
+    {
+      title: 'Trending AI anxieties',
+      value: trendingAnxieties.length ? `Top ${trendingAnxieties.length}` : 'Watching',
+      summary: 'Fear areas with the heaviest recent signal density.',
+      detail: 'Ranked from recent STA publishing activity by fear area.',
+      sourceLabel: LIVE_SOURCE_LABEL,
+      tone: 'medium',
+      items: trendingAnxieties.length ? trendingAnxieties : ['No recent concentration yet'],
+      href: '/survival-areas/work-money',
+      hrefLabel: 'Browse fear areas',
+    },
+    {
+      title: 'New AI incidents added',
+      value: `${trailing14.length}`,
+      summary: 'New editorially logged pressure items in the last 14 days of coverage.',
+      detail: 'This includes new analyses and incident-driven dispatches published by STA.',
+      sourceLabel: LIVE_SOURCE_LABEL,
+      tone: trailing14.length >= 4 ? 'high' : trailing14.length >= 2 ? 'medium' : 'low',
+      href: '/posts',
+      hrefLabel: 'Open the archive',
+    },
+    {
+      title: 'Tech layoff watch',
+      value: `${workMoney45.length}`,
+      summary: 'Work & Money dispatches in the last 45 days.',
+      detail: leadWorkMoney
+        ? `Latest signal: ${leadWorkMoney.data.title}`
+        : 'Waiting for the next work-and-money dispatch.',
+      sourceLabel: LIVE_SOURCE_LABEL,
+      tone: workMoney45.length >= 3 ? 'high' : workMoney45.length >= 1 ? 'medium' : 'low',
+      href: '/survival-areas/work-money',
+      hrefLabel: 'Open Work & Money',
+    },
+  ];
+
+  const threatCards: HomepageThreatCard[] = [...SURVIVAL_HUBS]
+    .sort((a, b) => a.order - b.order)
+    .map((hub) => ({
+      hub,
+      ...EDITORIAL_THREAT_MODEL[hub.key],
+      latestPost: eligiblePosts.find((post) => getPillarFromPost(post) === hub.key),
+    }));
+
+  return {
+    anchorDateLabel: formatDate(anchorDate),
+    leadPost: placement.featured,
+    liveModules,
+    threatCards,
+    macroGauges: EDITORIAL_MACRO_GAUGES,
+    impactItems: eligiblePosts.slice(0, 5),
+    votePrompt: 'Which fear area feels most personally urgent right now?',
+    voteOptions: VOTE_OPTIONS,
+  };
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,211 +1,67 @@
 ---
-import Layout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import { formatDate } from '../utils/format';
+import CredibilityPanel from '../components/CredibilityPanel.astro';
+import PlaybookOffer from '../components/PlaybookOffer.astro';
 import PostCard from '../components/PostCard.astro';
+import PressureRoom from '../components/homepage/PressureRoom.astro';
 import SubscribeInline from '../components/SubscribeInline';
 import { SURVIVAL_HUBS } from '../data/hubs';
 import { buildHomepagePlacement } from '../data/homepage';
-import CredibilityPanel from '../components/CredibilityPanel.astro';
-import { getAuthorProfile } from '../data/authors';
-import PlaybookOffer from '../components/PlaybookOffer.astro';
+import { buildHomepageBoard } from '../data/homepageBoard';
+import Layout from '../layouts/BaseLayout.astro';
 
 const posts = await getCollection('posts');
-const { featured, latestIntelligence, editorPicks, fearAreaSpotlights, remaining } = buildHomepagePlacement(posts);
+const { editorPicks, remaining } = buildHomepagePlacement(posts);
+const board = buildHomepageBoard(posts);
 const survivalAreas = [...SURVIVAL_HUBS].sort((a, b) => a.order - b.order);
-const featuredAuthor = featured ? getAuthorProfile(featured.data.author) : undefined;
 ---
 
 <Layout title="Survive the AI - Prepare, adapt, and stay ahead">
-  <main class="bg-white py-16 text-neutral-900 sm:py-20">
-    <div class="mx-auto max-w-screen-xl space-y-16 px-4 sm:px-6 lg:px-8">
-      <section class="py-6 sm:py-8" data-testid="homepage-hero">
-        <div class="grid gap-8 lg:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)] lg:items-end">
-          <div class="space-y-5">
+  <main class="bg-[radial-gradient(circle_at_top,_rgba(23,23,23,0.06),_transparent_34%),linear-gradient(to_bottom,_#fafafa,_#f5f5f5_28%,_#ffffff_60%)] py-14 text-neutral-900 sm:py-18">
+    <div class="mx-auto max-w-screen-xl space-y-14 px-4 sm:px-6 lg:px-8">
+      <section class="py-2 sm:py-4" data-testid="homepage-hero">
+        <div class="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(280px,0.9fr)] lg:items-end">
+          <div class="space-y-4">
             <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Survive the AI</p>
             <div class="max-w-4xl space-y-4">
-              <h1 class="text-3xl font-black leading-[1.05] tracking-tight text-neutral-900 sm:text-[2.7rem] lg:text-[3.6rem]">
-                The AI Flood Is Here. Learn to Adapt Before You're Forced To.
+              <h1 class="text-3xl font-black leading-[1.02] tracking-tight text-neutral-950 sm:text-[2.8rem] lg:text-[3.7rem]">
+                The pressure is no longer theoretical. Track where AI is pressing first.
               </h1>
               <p class="max-w-3xl text-base leading-relaxed text-neutral-600 sm:text-lg">
-                SurviveTheAI is an editorial survival guide for a world reshaped by artificial intelligence. We track what AI is changing
-                across jobs, education, attention, relationships, and institutions, then translate those shifts into clear next moves for
-                people and families.
+                SurviveTheAI is an editorial survival guide for people navigating AI pressure across work, school, relationships, attention,
+                and institutions. The homepage now opens with the board: what STA is seeing, how the editor scores it, and where to read
+                deeper next.
               </p>
             </div>
           </div>
-          <div class="rounded-3xl border border-neutral-200 bg-neutral-50 p-6 shadow-sm sm:p-7">
-            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">What you'll find here</p>
+          <div class="rounded-3xl border border-neutral-200 bg-white/90 p-6 shadow-[0_18px_48px_-36px_rgba(0,0,0,0.35)] backdrop-blur">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">How to use the board</p>
             <ul class="mt-4 space-y-3 text-sm leading-relaxed text-neutral-700">
-              <li>Evidence-based reporting on where AI pressure is building first.</li>
-              <li>Editorial context that separates structural risk from passing hype.</li>
-              <li>Practical survival paths for people who need to act before the system catches up.</li>
+              <li>Read the near-live modules as recent signal summaries, not real-time feeds.</li>
+              <li>Treat the threat cards and gauges as clearly labeled editorial judgment.</li>
+              <li>Use the impact feed, fear areas, and Start Here path to route into full reporting.</li>
             </ul>
           </div>
         </div>
       </section>
 
-      {featured ? (
-        <section class="space-y-5" data-testid="featured-story-section">
-          <div class="max-w-3xl space-y-1">
-            <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Featured Analysis</p>
-            <h2 class="text-2xl font-black text-neutral-900 sm:text-3xl">Most urgent now</h2>
-          </div>
-          <div class="overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-xl ring-1 ring-neutral-100">
-            <div class="grid gap-0 lg:grid-cols-[1.1fr_0.9fr] lg:items-stretch">
-              <a
-                href={`/posts/${featured.slug}/`}
-                class="block overflow-hidden bg-neutral-100 transition lg:order-last lg:border-l lg:border-neutral-200"
-              >
-                <div class="relative h-full min-h-[260px] sm:min-h-[320px]">
-                  <img
-                    src={featured.data.heroImage}
-                    alt={featured.data.heroImageAlt ?? featured.data.title}
-                    class="absolute inset-0 h-full w-full object-cover"
-                    loading="lazy"
-                    decoding="async"
-                    width="1200"
-                    height="630"
-                  />
-                </div>
-              </a>
-              <div class="space-y-6 px-6 py-8 sm:px-8 sm:py-10 lg:py-12">
-                <div class="space-y-3">
-                  <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Featured analysis</p>
-                  <h3 class="text-3xl font-black tracking-tight text-neutral-900 sm:text-4xl lg:text-5xl">{featured.data.title}</h3>
-                  <p class="max-w-3xl text-lg text-neutral-700 sm:text-xl">{featured.data.description}</p>
-                </div>
-                <div class="flex flex-wrap items-center gap-3 text-sm text-neutral-600">
-                  <span>{formatDate(featured.data.date)}</span>
-                  <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
-                  <span>{`By ${featuredAuthor?.displayName}`}</span>
-                  <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
-                  <a
-                    href="/impact-score-methodology"
-                    class="underline decoration-neutral-300 underline-offset-4 transition hover:text-neutral-800"
-                    data-testid="featured-impact-score-link"
-                  >
-                    Impact Score {featured.data.impact_score}
-                  </a>
-                </div>
-                <div class="flex flex-wrap gap-3 pt-2">
-                  <a
-                    href={`/posts/${featured.slug}/`}
-                    class="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
-                  >
-                    Read the urgent story
-                  </a>
-                  <a
-                    href="/posts"
-                    class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-6 py-3 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
-                  >
-                    Browse the Survival Library
-                  </a>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-      ) : (
-        <section class="space-y-3" data-testid="featured-story-section">
-          <h2 class="text-3xl font-extrabold sm:text-4xl">No posts published yet.</h2>
-          <p class="text-neutral-600">Come back soon for the latest analysis on surviving the AI disruption.</p>
-        </section>
-      )}
-
-      {latestIntelligence.length > 0 && (
-        <section class="space-y-6" data-testid="latest-intelligence-section">
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-            <div class="max-w-3xl space-y-1">
-              <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Latest intelligence</p>
-              <h2 class="text-2xl font-black text-neutral-900 sm:text-3xl">Newest signals across the fear areas</h2>
-            </div>
-            <a
-              href="/posts"
-              class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
-            >
-              View the full library
-            </a>
-          </div>
-          <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
-            {latestIntelligence.map((post) => (
-              <PostCard post={post} />
-            ))}
-          </div>
-        </section>
-      )}
-
-      <section class="space-y-6" data-testid="survival-areas-section">
-        <div class="space-y-1">
-          <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Fear Areas</p>
-          <h2 class="text-2xl font-black text-neutral-900 sm:text-3xl">Browse by fear area</h2>
-        </div>
-        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {survivalAreas.map((area) => (
-            <a
-              href={`${area.slug}/`}
-              class="group flex h-full flex-col justify-between gap-3 rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400"
-              data-testid="survival-area-tile"
-            >
-              <div class="flex items-start gap-3">
-                <span class="mt-1 inline-block h-2 w-2 rounded-full" style={`background:${area.color}`} aria-hidden="true" />
-                <div class="space-y-1">
-                  <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-500">Fear area</p>
-                  <h3 class="text-lg font-bold leading-tight text-neutral-900 transition group-hover:text-neutral-700">{area.shortName}</h3>
-                </div>
-              </div>
-              <p class="text-sm leading-relaxed text-neutral-600">{area.tagline}</p>
-            </a>
-          ))}
-        </div>
-      </section>
-
-      <section class="space-y-6" data-testid="fear-area-representatives-section">
-        <div class="space-y-1">
-          <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">One from each fear area</p>
-          <h2 class="text-2xl font-black text-neutral-900 sm:text-3xl">Across the whole map</h2>
-        </div>
-        <div class="grid grid-cols-1 gap-6 lg:grid-cols-5">
-          {fearAreaSpotlights.map((item) => (
-            <div class="space-y-3" data-testid="fear-area-representative">
-              <div class="space-y-1">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">Fear area</p>
-                <h3 class="text-lg font-black text-neutral-900" data-testid="fear-area-representative-label">{item.hub.shortName}</h3>
-              </div>
-              {item.post ? (
-                <PostCard post={item.post} />
-              ) : (
-                <a
-                  href={item.fallbackHref}
-                  class="flex h-full flex-col justify-between rounded-3xl border border-neutral-200 bg-neutral-50 p-5 shadow-sm transition hover:border-neutral-300 hover:bg-white"
-                  data-testid="fear-area-fallback"
-                >
-                  <div class="space-y-3">
-                    <p class="text-sm font-semibold uppercase tracking-[0.2em] text-neutral-500">Go deeper</p>
-                    <p class="text-sm leading-relaxed text-neutral-700">Open this fear area hub for the latest reporting, guidance, and next steps.</p>
-                  </div>
-                  <span class="mt-5 inline-flex items-center justify-center rounded-full border border-neutral-300 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950">
-                    {item.fallbackLabel}
-                  </span>
-                </a>
-              )}
-            </div>
-          ))}
-        </div>
-      </section>
+      <PressureRoom board={board} />
 
       {editorPicks.length > 0 && (
         <section class="space-y-6" data-testid="start-here-section">
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div class="max-w-3xl space-y-1">
               <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Start Here / Editor's Picks</p>
-              <h2 class="text-2xl font-black text-neutral-900 sm:text-3xl">Start here</h2>
-              <p class="text-neutral-600">New readers should use the guided path first, then drop into the full library once the map makes sense.</p>
+              <h2 class="text-2xl font-black text-neutral-950 sm:text-3xl">Use the board, then take the guided path</h2>
+              <p class="text-neutral-600">
+                New readers should map the pressure first, then use Start Here and these editor-selected posts to understand the site’s
+                logic.
+              </p>
             </div>
             <div class="flex flex-wrap gap-3">
               <a
                 href="/start-here"
-                class="inline-flex items-center justify-center rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+                class="inline-flex items-center justify-center rounded-full bg-neutral-950 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
                 data-testid="start-here-guided-link"
                 data-analytics-event="start_here_entry_click"
                 data-analytics-location="homepage-start-here-section"
@@ -229,15 +85,45 @@ const featuredAuthor = featured ? getAuthorProfile(featured.data.author) : undef
         </section>
       )}
 
+      <section class="space-y-6" data-testid="survival-areas-section">
+        <div class="space-y-1">
+          <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Fear Areas</p>
+          <h2 class="text-2xl font-black text-neutral-950 sm:text-3xl">Route by fear area</h2>
+          <p class="max-w-3xl text-neutral-600">
+            The board condenses the pressure. The fear-area hubs hold the ongoing reporting, practical framing, and deeper archive for each
+            zone.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
+          {survivalAreas.map((area) => (
+            <a
+              href={`${area.slug}/`}
+              class="group flex h-full flex-col justify-between gap-4 rounded-2xl border border-neutral-200 bg-white p-5 shadow-[0_16px_40px_-34px_rgba(0,0,0,0.35)] transition hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-[0_20px_48px_-32px_rgba(0,0,0,0.42)] focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400"
+              data-testid="survival-area-tile"
+            >
+              <div class="space-y-3">
+                <div class="flex items-center gap-3">
+                  <span class="inline-block h-2.5 w-2.5 rounded-full" style={`background:${area.color}`} aria-hidden="true" />
+                  <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">Fear area</p>
+                </div>
+                <h3 class="text-lg font-black leading-tight text-neutral-900 transition group-hover:text-neutral-700">{area.shortName}</h3>
+                <p class="text-sm leading-relaxed text-neutral-600">{area.tagline}</p>
+              </div>
+              <span class="text-sm font-semibold text-neutral-900">Open the hub</span>
+            </a>
+          ))}
+        </div>
+      </section>
+
       <PlaybookOffer
         eyebrow="Reader offer"
         title="Get the free Survival Playbook before the pressure gets personal"
-        description="If you want one clear next-step resource, use the playbook. It pulls together STA's practical checklists without turning the site into a sales funnel."
+        description="If you want one clear next-step resource, use the playbook. It pulls together STA's practical checklists without turning the homepage into a funnel."
         href="/playbook"
         ctaLabel="Get the free playbook"
         secondaryHref="/start-here"
         secondaryLabel="Open Start Here"
-        disclaimer="Free reader resource. Integrated intentionally, not spammed everywhere."
+        disclaimer="Free reader resource. Intentional placement, not constant interruption."
         testId="homepage-playbook-offer"
         primaryAnalyticsEvent="playbook_cta_click"
         primaryAnalyticsLocation="homepage-playbook-offer"
@@ -255,29 +141,30 @@ const featuredAuthor = featured ? getAuthorProfile(featured.data.author) : undef
         />
       </section>
 
-      <CredibilityPanel
-        eyebrow="Why trust STA"
-        title="Named reporting, visible standards, clear ownership"
-      />
+      <CredibilityPanel eyebrow="Why trust STA" title="Named reporting, visible standards, clear ownership" />
 
       {remaining.length > 0 && (
-        <section class="space-y-6" data-testid="library-cta-section">
+        <section class="space-y-5" data-testid="library-cta-section">
           <div class="space-y-1">
             <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Library / Archive</p>
-            <h2 class="text-2xl font-black text-neutral-900 sm:text-3xl">Explore the Survival Library</h2>
+            <h2 class="text-2xl font-black text-neutral-950 sm:text-3xl">Keep moving through the reporting</h2>
+            <p class="max-w-3xl text-neutral-600">
+              The homepage board is the front door, not the whole system. The full library is where the longer survival map keeps filling
+              in.
+            </p>
           </div>
           <div class="flex flex-wrap gap-3">
             <a
               href="/posts"
-              class="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+              class="inline-flex items-center justify-center rounded-full bg-neutral-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
             >
               Go to the Survival Library
             </a>
             <a
-              href="/survival-areas/work-money"
+              href="/impact-score-methodology"
               class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-6 py-3 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
             >
-              Browse Fear Areas
+              Read the Impact Score methodology
             </a>
           </div>
         </section>

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,58 +1,35 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Homepage layout', () => {
-  test('renders one global header and the locked homepage sections without repeating the featured post in latest', async ({ page }) => {
+  test('renders the board-led homepage shell and core conversion surfaces', async ({ page }) => {
     await page.goto('/');
 
     await expect(page.getByTestId('navbar')).toHaveCount(1);
     await expect(page.getByTestId('homepage-hero')).toBeVisible();
-    await expect(page.getByTestId('featured-story-section')).toBeVisible();
-    await expect(page.getByTestId('latest-intelligence-section')).toBeVisible();
-    await expect(page.getByTestId('survival-areas-section')).toBeVisible();
-    await expect(page.getByTestId('fear-area-representatives-section')).toBeVisible();
+    await expect(page.getByTestId('pressure-room-section')).toBeVisible();
     await expect(page.getByTestId('start-here-section')).toBeVisible();
-    await expect(page.getByTestId('homepage-subscribe')).toBeVisible();
+    await expect(page.getByTestId('survival-areas-section')).toBeVisible();
     await expect(page.getByTestId('homepage-playbook-offer')).toBeVisible();
+    await expect(page.getByTestId('homepage-subscribe')).toBeVisible();
     await expect(page.getByTestId('credibility-panel')).toBeVisible();
     await expect(page.getByTestId('library-cta-section')).toBeVisible();
 
-    const featuredHref = await page.getByTestId('featured-story-section').locator('a[href^="/posts/"]').first().getAttribute('href');
-    const featuredSlug = featuredHref?.replace(/\/posts\/|\/$/g, '');
+    await expect(page.getByTestId('pressure-room-live-modules').locator('article')).toHaveCount(4);
+    await expect(page.getByTestId('pressure-room-threat-card')).toHaveCount(5);
+    await expect(page.getByTestId('pressure-room-macro-gauges').locator('article')).toHaveCount(3);
+    await expect(page.getByTestId('pressure-room-impact-item')).toHaveCount(5);
+    await expect(page.getByTestId('pressure-room-vote')).toContainText('Local browser vote for now.');
 
-    const latestCards = page.locator('[data-testid="latest-intelligence-section"] [data-testid="post-card"]');
-    await expect(latestCards).toHaveCount(3);
-
-    const latestSlugs = await latestCards.evaluateAll((links) =>
-      links
-        .map((link) => (link.getAttribute('href') ?? '').replace(/\/posts\/|\/$/g, ''))
-        .filter(Boolean),
+    await expect(page.getByTestId('pressure-room-lead-story')).toContainText("AI Agents Aren't Tools. They're Headcount Compression.");
+    await expect(page.getByTestId('pressure-room-lead-story').getByRole('link', { name: /Impact Score/i })).toHaveAttribute(
+      'href',
+      '/impact-score-methodology',
     );
-    expect(latestSlugs).not.toContain(featuredSlug);
-
-    const latestAreas = await page
-      .locator('[data-testid="latest-intelligence-section"] [data-testid="post-card-meta"]')
-      .evaluateAll((meta) =>
-        meta
-          .map((node) => node.textContent?.trim() ?? '')
-          .map((text) => text.split('•')[0]?.trim() || text)
-          .filter(Boolean),
-      );
-    expect(new Set(latestAreas).size).toBe(3);
-
-    await expect(page.getByTestId('featured-story-section').getByRole('heading', { level: 3 })).toHaveText(
-      "AI Agents Aren't Tools. They're Headcount Compression.",
-    );
-
-    const fearAreaSection = page.getByTestId('fear-area-representatives-section');
-    await expect(fearAreaSection.getByTestId('fear-area-representative')).toHaveCount(5);
-    await expect(fearAreaSection.locator('[data-testid="post-card"]')).toHaveCount(4);
-    await expect(fearAreaSection.getByTestId('fear-area-fallback')).toHaveCount(1);
-    await expect(fearAreaSection.getByTestId('fear-area-fallback')).toContainText('Browse System Shock');
 
     await expect(page.locator('[data-testid="start-here-section"] [data-testid="post-card"]')).toHaveCount(3);
 
     const bodyText = await page.evaluate(() => document.body.innerText);
-    expect(bodyText).not.toMatch(/ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢|ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œ|ÃƒÂ¢Ã¢â€šÂ¬|ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“|ÃƒÆ’/);
+    expect(bodyText).not.toMatch(/ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â‚¬Å¾Ã‚Â¢|ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“|ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬|ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œ|ÃƒÆ’Ã†â€™/);
     await expect(page.locator('a[href="/posts/pro-template-demo/"]')).toHaveCount(0);
     await expect(page.locator('a[href="/posts/ai-companionship/"]')).toHaveCount(0);
     await expect(page.locator('a[href="/posts/cognitive-erosion/"]')).toHaveCount(0);
@@ -70,11 +47,9 @@ test.describe('Homepage layout', () => {
 
     expect(sectionOrder).toEqual([
       'homepage-hero',
-      'featured-story-section',
-      'latest-intelligence-section',
-      'survival-areas-section',
-      'fear-area-representatives-section',
+      'pressure-room-section',
       'start-here-section',
+      'survival-areas-section',
       'homepage-playbook-offer',
       'homepage-subscribe',
       'credibility-panel',
@@ -82,7 +57,27 @@ test.describe('Homepage layout', () => {
     ]);
   });
 
-  test('fear areas section links to the five hubs and the representative section gives one post per area', async ({ page }) => {
+  test('pressure room keeps its honest data separation and routes back into reporting', async ({ page }) => {
+    await page.goto('/');
+
+    const pressureRoom = page.getByTestId('pressure-room-section');
+    await expect(pressureRoom).toContainText('Near-live modules summarize fresh STA coverage.');
+    await expect(pressureRoom).toContainText('Threat cards and macro gauges are explicit editorial judgments.');
+    await expect(pressureRoom).toContainText('Board timestamp:');
+
+    const impactItems = page.getByTestId('pressure-room-impact-item');
+    const hrefs = await impactItems.evaluateAll((anchors) => anchors.map((anchor) => anchor.getAttribute('href')).filter(Boolean));
+    expect(hrefs.length).toBe(5);
+    expect(hrefs.every((href) => href?.startsWith('/posts/'))).toBe(true);
+
+    await expect(page.getByTestId('pressure-room-threat-cards').getByRole('link', { name: 'Open Work & Money' })).toHaveAttribute(
+      'href',
+      '/survival-areas/work-money/',
+    );
+    await expect(pressureRoom.getByRole('link', { name: 'Open the hub' })).toHaveCount(0);
+  });
+
+  test('fear areas section links to the five hubs', async ({ page }) => {
     await page.goto('/');
 
     const survivalCards = page.getByTestId('survival-areas-section').getByTestId('survival-area-tile');
@@ -91,20 +86,10 @@ test.describe('Homepage layout', () => {
     const hrefs = await survivalCards.evaluateAll((anchors) => anchors.map((anchor) => anchor.getAttribute('href')).filter(Boolean));
     expect(new Set(hrefs).size).toBe(5);
     await expect(survivalCards.first()).toContainText('Fear area');
-
-    const representativeHeadings = await page
-      .getByTestId('fear-area-representatives-section')
-      .getByTestId('fear-area-representative-label')
-      .evaluateAll((headings) => headings.map((heading) => heading.textContent?.trim()).filter(Boolean));
-    expect(new Set(representativeHeadings).size).toBe(5);
   });
 
   test('homepage and hub surfaced post cards use the shared metadata and spacing treatment', async ({ page }) => {
     await page.goto('/');
-
-    const latestCards = page.locator('[data-testid="latest-intelligence-section"] [data-testid="post-card"]');
-    await expect(latestCards.locator('[data-testid="post-card-meta"]')).toHaveCount(3);
-    await expect(latestCards.locator('[data-testid="post-card-impact"]')).toHaveCount(3);
 
     const startHereCards = page.locator('[data-testid="start-here-section"] [data-testid="post-card"]');
     await expect(startHereCards.locator('[data-testid="post-card-meta"]')).toHaveCount(3);
@@ -123,7 +108,7 @@ test.describe('Homepage layout', () => {
     await page.goto('/survival-areas/kids-school/');
 
     const bodyText = await page.evaluate(() => document.body.innerText);
-    expect(bodyText).not.toMatch(/ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢|ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œ|ÃƒÂ¢Ã¢â€šÂ¬|ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“|ÃƒÆ’/);
+    expect(bodyText).not.toMatch(/ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â‚¬Å¾Ã‚Â¢|ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“|ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬|ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œ|ÃƒÆ’Ã†â€™/);
     await expect(page.getByText("What's happening")).toBeVisible();
   });
 
@@ -140,18 +125,6 @@ test.describe('Homepage layout', () => {
     await expect(page.getByTestId('mobile-menu')).toBeVisible();
   });
 
-  test('featured story stays distinct from latest intelligence and editor picks', async ({ page }) => {
-    await page.goto('/');
-
-    await expect(page.getByTestId('featured-story-section')).toContainText('Featured analysis');
-    await expect(page.getByTestId('featured-story-section').locator('[data-testid="post-card"]')).toHaveCount(0);
-    await expect(page.getByTestId('featured-story-section')).toContainText('By Lee Cuevas');
-    await expect(page.getByTestId('featured-impact-score-link')).toHaveAttribute('href', '/impact-score-methodology');
-    await expect(page.getByTestId('latest-intelligence-section')).toContainText('Newest signals across the fear areas');
-    await expect(page.getByTestId('start-here-section')).toContainText('Start here');
-    await expect(page.getByTestId('start-here-guided-link')).toHaveAttribute('href', '/start-here');
-  });
-
   test('start here page gives new readers a guided path into trust and content surfaces', async ({ page }) => {
     await page.goto('/start-here/');
 
@@ -160,7 +133,10 @@ test.describe('Homepage layout', () => {
     await expect(page.getByTestId('start-here-featured-link')).toHaveAttribute('href', '/posts/ai-agents-arent-tools/');
     await expect(page.getByTestId('start-here-featured-link')).toHaveAttribute('data-analytics-event', 'start_here_content_click');
     await expect(page.getByTestId('start-here-steps').getByRole('link', { name: 'How we research' })).toHaveAttribute('href', '/how-we-research');
-    await expect(page.getByTestId('start-here-steps').getByRole('link', { name: 'Impact Score methodology' })).toHaveAttribute('href', '/impact-score-methodology');
+    await expect(page.getByTestId('start-here-steps').getByRole('link', { name: 'Impact Score methodology' })).toHaveAttribute(
+      'href',
+      '/impact-score-methodology',
+    );
     await expect(page.getByTestId('start-here-editor-picks').getByTestId('post-card')).toHaveCount(3);
     await expect(page.getByTestId('start-here-playbook-offer')).toBeVisible();
     await expect(page.getByTestId('start-here-playbook-offer').getByRole('link', { name: 'Get the free playbook' })).toHaveAttribute(
@@ -192,7 +168,10 @@ test.describe('Homepage layout', () => {
     await page.goto('/');
 
     await expect(page.getByTestId('homepage-playbook-offer')).toContainText('Get the free Survival Playbook');
-    await expect(page.getByTestId('homepage-playbook-offer').getByRole('link', { name: 'Get the free playbook' })).toHaveAttribute('href', '/playbook');
+    await expect(page.getByTestId('homepage-playbook-offer').getByRole('link', { name: 'Get the free playbook' })).toHaveAttribute(
+      'href',
+      '/playbook',
+    );
     await expect(page.getByTestId('homepage-playbook-offer').getByRole('link', { name: 'Get the free playbook' })).toHaveAttribute(
       'data-analytics-event',
       'playbook_cta_click',


### PR DESCRIPTION
## What changed
- refactored `src/pages/index.astro` into a board-led editorial homepage with a short hero and a new AI Pressure Room directly underneath
- added Astro-native homepage board components for live-like modules, editorial threat cards, macro gauges, impact-score routing, and a local vote widget
- added `src/data/homepageBoard.ts` as the local board/config seam for future API wiring
- updated homepage Playwright coverage for the new section order and board behavior

## Why it changed
- the previous homepage was article-first and did not surface STA's editorial pressure-board concept prominently enough
- this refactor keeps the existing STA shell and design language while shifting the visual tone darker and more board-like without turning the site into a disconnected app dashboard
- the data model now clearly separates near-live inputs, editorial scores, and community voting so future live integrations have clean boundaries

## User impact
- readers land on a tighter editorial framing section and immediately see where AI pressure is building
- the homepage still routes strongly into posts, fear-area hubs, Start Here, newsletter signup, and trust/credibility surfaces
- the implementation stays Astro-native except for the existing newsletter island and a lightweight inline vote script

## Validation
- `npm run build`
- `npm.cmd test -- tests/homepage.spec.ts`
