### PR TITLE
Align homepage to approved pressure-board canvas

### DIFF
--- a/src/components/CredibilityPanel.astro
+++ b/src/components/CredibilityPanel.astro
@@ -5,35 +5,60 @@ const {
   eyebrow = 'Trust',
   title = 'Who publishes this',
   summary = SITE_CREDIBILITY.summary,
+  variant = 'default',
 } = Astro.props as {
   eyebrow?: string;
   title?: string;
   summary?: string;
+  variant?: 'default' | 'board';
 };
 ---
 
-<section class="rounded-3xl border border-neutral-200 bg-neutral-50 p-6 shadow-sm" data-testid="credibility-panel">
+<section
+  class:list={[
+    'rounded-3xl p-6',
+    variant === 'board'
+      ? 'border border-white/10 bg-[linear-gradient(180deg,rgba(23,23,23,0.94),rgba(10,10,10,0.98))] shadow-[0_20px_60px_-36px_rgba(0,0,0,0.8)]'
+      : 'border border-neutral-200 bg-neutral-50 shadow-sm',
+  ]}
+  data-testid="credibility-panel"
+>
   <div class="space-y-3">
     <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">{eyebrow}</p>
-    <h2 class="text-2xl font-black text-neutral-900 sm:text-3xl">{title}</h2>
-    <p class="max-w-4xl text-neutral-700">{summary}</p>
+    <h2 class:list={['text-2xl font-black sm:text-3xl', variant === 'board' ? 'text-white' : 'text-neutral-900']}>{title}</h2>
+    <p class:list={['max-w-4xl', variant === 'board' ? 'text-neutral-300' : 'text-neutral-700']}>{summary}</p>
   </div>
   <div class="mt-5 flex flex-wrap gap-3">
     <a
       href={SITE_CREDIBILITY.aboutHref}
-      class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950"
+      class:list={[
+        'inline-flex items-center justify-center rounded-full border px-4 py-2 text-sm font-semibold transition',
+        variant === 'board'
+          ? 'border-white/15 text-white hover:border-white/30 hover:bg-white/5'
+          : 'border-neutral-300 text-neutral-900 hover:border-neutral-500 hover:text-neutral-950',
+      ]}
     >
       Meet the team
     </a>
     <a
       href={SITE_CREDIBILITY.standardsHref}
-      class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950"
+      class:list={[
+        'inline-flex items-center justify-center rounded-full border px-4 py-2 text-sm font-semibold transition',
+        variant === 'board'
+          ? 'border-white/15 text-white hover:border-white/30 hover:bg-white/5'
+          : 'border-neutral-300 text-neutral-900 hover:border-neutral-500 hover:text-neutral-950',
+      ]}
     >
       Read our standards
     </a>
     <a
       href={SITE_CREDIBILITY.contactHref}
-      class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950"
+      class:list={[
+        'inline-flex items-center justify-center rounded-full border px-4 py-2 text-sm font-semibold transition',
+        variant === 'board'
+          ? 'border-white/15 text-white hover:border-white/30 hover:bg-white/5'
+          : 'border-neutral-300 text-neutral-900 hover:border-neutral-500 hover:text-neutral-950',
+      ]}
     >
       Contact the editor
     </a>

--- a/src/components/PlaybookOffer.astro
+++ b/src/components/PlaybookOffer.astro
@@ -27,24 +27,36 @@ const {
   primaryAnalyticsLocation?: string;
   secondaryAnalyticsEvent?: string;
   secondaryAnalyticsLocation?: string;
+  variant?: 'default' | 'board';
 };
+const variant = Astro.props.variant ?? 'default';
 ---
 
 <section
-  class="rounded-3xl border border-neutral-200 bg-white p-6 shadow-[0_12px_40px_-28px_rgba(0,0,0,0.35)] sm:p-8"
+  class:list={[
+    'rounded-3xl p-6 sm:p-8',
+    variant === 'board'
+      ? 'border border-white/10 bg-[linear-gradient(135deg,rgba(23,23,23,0.94),rgba(10,10,10,0.98))] shadow-[0_24px_70px_-42px_rgba(0,0,0,0.8)]'
+      : 'border border-neutral-200 bg-white shadow-[0_12px_40px_-28px_rgba(0,0,0,0.35)]',
+  ]}
   data-testid={testId}
 >
   <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
     <div class="max-w-2xl space-y-3">
       <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-500">{eyebrow}</p>
-      <h2 class="text-2xl font-black tracking-tight text-neutral-900 sm:text-3xl">{title}</h2>
-      <p class="text-base leading-relaxed text-neutral-700 sm:text-lg">{description}</p>
+      <h2 class:list={['text-2xl font-black tracking-tight sm:text-3xl', variant === 'board' ? 'text-white' : 'text-neutral-900']}>{title}</h2>
+      <p class:list={['text-base leading-relaxed sm:text-lg', variant === 'board' ? 'text-neutral-300' : 'text-neutral-700']}>{description}</p>
       <p class="text-xs font-medium uppercase tracking-[0.2em] text-neutral-500">{disclaimer}</p>
     </div>
     <div class="flex flex-col gap-3 sm:flex-row">
       <a
         href={href}
-        class="inline-flex items-center justify-center rounded-full bg-neutral-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+        class:list={[
+          'inline-flex items-center justify-center rounded-full px-5 py-3 text-sm font-semibold transition focus:outline-none focus-visible:ring-2',
+          variant === 'board'
+            ? 'bg-white text-neutral-950 hover:bg-neutral-200 focus-visible:ring-white/40'
+            : 'bg-neutral-900 text-white hover:bg-neutral-800 focus-visible:ring-neutral-700',
+        ]}
         data-analytics-event={primaryAnalyticsEvent}
         data-analytics-location={primaryAnalyticsLocation}
         data-analytics-label={ctaLabel}
@@ -54,7 +66,12 @@ const {
       {secondaryHref && secondaryLabel && (
         <a
           href={secondaryHref}
-          class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-5 py-3 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+          class:list={[
+            'inline-flex items-center justify-center rounded-full border px-5 py-3 text-sm font-semibold transition focus:outline-none focus-visible:ring-2',
+            variant === 'board'
+              ? 'border-white/15 text-white hover:border-white/30 hover:bg-white/5 focus-visible:ring-white/30'
+              : 'border-neutral-300 text-neutral-900 hover:border-neutral-500 hover:text-neutral-950 focus-visible:ring-neutral-700',
+          ]}
           data-analytics-event={secondaryAnalyticsEvent}
           data-analytics-location={secondaryAnalyticsLocation}
           data-analytics-label={secondaryLabel}

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -2,7 +2,10 @@
 import type { PostEntry } from '../content/config';
 import PostCardMeta from './PostCardMeta.astro';
 
-const { post } = Astro.props as { post: PostEntry };
+const { post, variant = 'default' } = Astro.props as {
+  post: PostEntry;
+  variant?: 'default' | 'board';
+};
 
 const FALLBACK_HERO = '/images/placeholder-hero.svg';
 const imageSrc = (post.data.heroImageThumb ?? post.data.heroImage)?.trim() || FALLBACK_HERO;
@@ -11,10 +14,15 @@ const imageAlt = post.data.heroImageAlt ?? post.data.title;
 
 <a
   href={`/posts/${post.slug}/`}
-  class="group flex h-full flex-col overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400"
+  class:list={[
+    'group flex h-full flex-col overflow-hidden rounded-3xl transition focus:outline-none focus-visible:ring-2',
+    variant === 'board'
+      ? 'border border-white/10 bg-neutral-950/85 shadow-[0_24px_60px_-38px_rgba(0,0,0,0.8)] hover:-translate-y-1 hover:border-white/20 hover:bg-neutral-950 focus-visible:ring-white/30'
+      : 'border border-neutral-200 bg-white shadow-sm hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-md focus-visible:ring-neutral-400',
+  ]}
   data-testid="post-card"
 >
-  <div class="relative aspect-[16/9] overflow-hidden bg-neutral-100">
+  <div class:list={['relative aspect-[16/9] overflow-hidden', variant === 'board' ? 'bg-neutral-900' : 'bg-neutral-100']}>
     <img
       src={imageSrc}
       alt={imageAlt}
@@ -27,14 +35,21 @@ const imageAlt = post.data.heroImageAlt ?? post.data.title;
   </div>
   <div class="flex flex-1 flex-col gap-5 p-5 sm:p-6">
     <div class="space-y-3">
-      <PostCardMeta post={post} />
-      <h3 class="text-xl font-bold leading-tight text-neutral-900 transition group-hover:text-neutral-700 line-clamp-2">
+      <PostCardMeta post={post} variant={variant} />
+      <h3
+        class:list={[
+          'text-xl font-bold leading-tight line-clamp-2 transition',
+          variant === 'board' ? 'text-white group-hover:text-neutral-200' : 'text-neutral-900 group-hover:text-neutral-700',
+        ]}
+      >
         {post.data.title}
       </h3>
-      <p class="text-sm leading-relaxed text-neutral-600 line-clamp-3">{post.data.description}</p>
+      <p class:list={['text-sm leading-relaxed line-clamp-3', variant === 'board' ? 'text-neutral-300' : 'text-neutral-600']}>
+        {post.data.description}
+      </p>
     </div>
-    <div class="mt-auto border-t border-neutral-100 pt-4">
-      <PostCardMeta post={post} compact={false} showImpact={true} />
+    <div class:list={['mt-auto pt-4', variant === 'board' ? 'border-t border-white/10' : 'border-t border-neutral-100']}>
+      <PostCardMeta post={post} compact={false} showImpact={true} variant={variant} />
     </div>
   </div>
 </a>

--- a/src/components/PostCardMeta.astro
+++ b/src/components/PostCardMeta.astro
@@ -4,10 +4,11 @@ import { TOPIC_CATEGORIES } from '../data/categories';
 import { getAuthorProfile } from '../data/authors';
 import { formatDate } from '../utils/format';
 
-const { post, compact = false, showImpact = false } = Astro.props as {
+const { post, compact = false, showImpact = false, variant = 'default' } = Astro.props as {
   post: PostEntry;
   compact?: boolean;
   showImpact?: boolean;
+  variant?: 'default' | 'board';
 };
 
 const categoryByKey = new Map(TOPIC_CATEGORIES.map((c) => [c.key, c]));
@@ -15,18 +16,29 @@ const primaryCategory = post.data.topics?.[0] ? categoryByKey.get(post.data.topi
 const categoryLabel = primaryCategory?.label ?? post.data.category ?? 'Key Topic';
 const dateLabel = formatDate(post.data.date);
 const authorLabel = getAuthorProfile(post.data.author).displayName;
-const metaClass = compact
-  ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
-  : 'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500';
-const impactClass = compact
-  ? 'text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
-  : 'text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500';
+const metaClass =
+  variant === 'board'
+    ? compact
+      ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
+      : 'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-400'
+    : compact
+      ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
+      : 'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500';
+const impactClass =
+  variant === 'board'
+    ? compact
+      ? 'text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-400'
+      : 'text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-300'
+    : compact
+      ? 'text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
+      : 'text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500';
+const dividerClass = variant === 'board' ? 'h-1 w-1 rounded-full bg-white/15' : 'h-1 w-1 rounded-full bg-neutral-300';
 ---
 
 {showImpact ? (
   <div class={impactClass} data-testid={compact ? 'compact-post-card-impact' : 'post-card-impact'}>
     <span>{`By ${authorLabel}`}</span>
-    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+    <span aria-hidden class={dividerClass} />
     <span data-testid={compact ? 'compact-impact-score-label' : 'impact-score-label'}>
       Impact Score {post.data.impact_score}
     </span>
@@ -34,7 +46,7 @@ const impactClass = compact
 ) : (
   <div class={metaClass} data-testid={compact ? 'compact-post-card-meta' : 'post-card-meta'}>
     <span>{categoryLabel}</span>
-    <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-300" />
+    <span aria-hidden class={dividerClass} />
     <span>{dateLabel}</span>
   </div>
 )}

--- a/src/components/SubscribeInline.tsx
+++ b/src/components/SubscribeInline.tsx
@@ -8,6 +8,7 @@ type SubscribeInlineProps = {
   helperText?: string;
   privacyText?: string;
   location?: string;
+  variant?: 'default' | 'board';
 };
 
 export default function SubscribeInline({
@@ -15,6 +16,7 @@ export default function SubscribeInline({
   helperText = 'Weekly signal, no hype: practical moves to protect your work, family, and focus.',
   privacyText = 'No spam. Unsubscribe anytime.',
   location = 'inline',
+  variant = 'default',
 }: SubscribeInlineProps) {
   const [status, setStatus] = useState<Status>('idle');
   const [message, setMessage] = useState<string>('');
@@ -129,20 +131,24 @@ export default function SubscribeInline({
 
   return (
     <section
-      className="rounded-3xl border border-neutral-200 bg-gradient-to-br from-white via-neutral-50 to-white p-6 shadow-[0_12px_40px_-28px_rgba(0,0,0,0.35)] sm:p-8"
+      className={`rounded-3xl p-6 sm:p-8 ${
+        variant === 'board'
+          ? 'border border-white/10 bg-[linear-gradient(135deg,rgba(23,23,23,0.94),rgba(10,10,10,0.98))] shadow-[0_24px_70px_-42px_rgba(0,0,0,0.8)]'
+          : 'border border-neutral-200 bg-gradient-to-br from-white via-neutral-50 to-white shadow-[0_12px_40px_-28px_rgba(0,0,0,0.35)]'
+      }`}
       aria-live="polite"
     >
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-500">Newsletter</p>
-        <h2 className="text-2xl font-black text-neutral-900 sm:text-3xl">{heading}</h2>
-        <p className="text-neutral-700">{helperText}</p>
+        <h2 className={`text-2xl font-black sm:text-3xl ${variant === 'board' ? 'text-white' : 'text-neutral-900'}`}>{heading}</h2>
+        <p className={variant === 'board' ? 'text-neutral-300' : 'text-neutral-700'}>{helperText}</p>
       </div>
 
       <form className="mt-6 space-y-4" onSubmit={onSubmit}>
         <input type="text" name="company" tabIndex={-1} autoComplete="off" className="hidden" aria-hidden="true" />
         <div className="flex flex-col gap-3 sm:flex-row">
           <div className="flex-1 space-y-2">
-            <label htmlFor={`email-${location}`} className="text-sm font-semibold text-neutral-800">
+            <label htmlFor={`email-${location}`} className={`text-sm font-semibold ${variant === 'board' ? 'text-neutral-200' : 'text-neutral-800'}`}>
               Email address
             </label>
             <input
@@ -150,7 +156,11 @@ export default function SubscribeInline({
               name="email"
               type="email"
               required
-              className="w-full rounded-xl border border-neutral-300 bg-white px-4 py-3 text-base text-neutral-900 shadow-sm transition focus:border-neutral-500 focus:outline-none focus:ring-2 focus:ring-neutral-500/30"
+              className={`w-full rounded-xl px-4 py-3 text-base shadow-sm transition focus:outline-none focus:ring-2 ${
+                variant === 'board'
+                  ? 'border border-white/10 bg-black/20 text-white placeholder:text-neutral-500 focus:border-white/25 focus:ring-white/15'
+                  : 'border border-neutral-300 bg-white text-neutral-900 focus:border-neutral-500 focus:ring-neutral-500/30'
+              }`}
               placeholder="you@example.com"
               autoComplete="email"
               disabled={status === 'loading' || status === 'disabled'}
@@ -160,7 +170,11 @@ export default function SubscribeInline({
           <div className="flex-none space-y-2 sm:pt-8">
             <button
               type="submit"
-              className="inline-flex w-full items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700 disabled:cursor-not-allowed disabled:opacity-70"
+              className={`inline-flex w-full items-center justify-center rounded-full px-6 py-3 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-70 ${
+                variant === 'board'
+                  ? 'bg-white text-neutral-950 hover:bg-neutral-200 focus-visible:ring-white/35'
+                  : 'bg-neutral-900 text-white hover:bg-neutral-800 focus-visible:ring-neutral-700'
+              }`}
               disabled={status === 'loading' || status === 'disabled'}
             >
               {status === 'loading' ? 'Subscribing...' : 'Subscribe'}

--- a/src/components/homepage/CommunityVote.astro
+++ b/src/components/homepage/CommunityVote.astro
@@ -7,7 +7,7 @@ const { prompt, options } = Astro.props as {
 };
 ---
 
-<section class="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-vote" data-vote-widget>
+<section class="rounded-[1.75rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-vote" data-vote-widget>
   <div class="space-y-1">
     <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Community vote</p>
     <h3 class="text-xl font-black text-white">{prompt}</h3>
@@ -20,7 +20,7 @@ const { prompt, options } = Astro.props as {
     {options.map((option) => (
       <button
         type="button"
-        class="vote-option flex items-start justify-between gap-4 rounded-2xl border border-white/10 bg-black/10 px-4 py-3 text-left transition hover:border-white/20 hover:bg-white/[0.07]"
+        class="vote-option flex items-start justify-between gap-4 rounded-[1.35rem] border border-white/10 bg-black/15 px-4 py-3 text-left transition hover:border-white/20 hover:bg-white/[0.07]"
         data-vote-option
         data-option-id={option.id}
       >

--- a/src/components/homepage/ImpactScoreFeed.astro
+++ b/src/components/homepage/ImpactScoreFeed.astro
@@ -8,7 +8,7 @@ const { items } = Astro.props as { items: PostEntry[] };
 const categoryByKey = new Map(TOPIC_CATEGORIES.map((category) => [category.key, category]));
 ---
 
-<section class="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-impact-feed">
+<section class="rounded-[1.75rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-impact-feed">
   <div class="flex items-end justify-between gap-4">
     <div class="space-y-1">
       <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Latest impact score items</p>
@@ -26,7 +26,7 @@ const categoryByKey = new Map(TOPIC_CATEGORIES.map((category) => [category.key, 
       return (
         <a
           href={`/posts/${post.slug}/`}
-          class="flex flex-col gap-4 rounded-2xl border border-white/10 bg-black/10 p-4 transition hover:border-white/20 hover:bg-white/[0.07] sm:flex-row sm:items-center sm:justify-between"
+          class="flex flex-col gap-4 rounded-[1.35rem] border border-white/10 bg-black/15 p-4 transition hover:border-white/20 hover:bg-white/[0.07] sm:flex-row sm:items-center sm:justify-between"
           data-testid="pressure-room-impact-item"
         >
           <div class="space-y-2">

--- a/src/components/homepage/LeadDispatchCard.astro
+++ b/src/components/homepage/LeadDispatchCard.astro
@@ -8,7 +8,7 @@ const { post } = Astro.props as { post?: PostEntry };
 const author = post ? getAuthorProfile(post.data.author) : undefined;
 ---
 
-<section class="overflow-hidden rounded-2xl border border-white/10 bg-white/5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-lead-story">
+<section class="overflow-hidden rounded-[1.8rem] border border-white/10 bg-white/[0.045] shadow-[0_22px_58px_-36px_rgba(0,0,0,0.82)]" data-testid="pressure-room-lead-story">
   {post ? (
     <>
       <a href={`/posts/${post.slug}/`} class="block">

--- a/src/components/homepage/LiveInputModules.astro
+++ b/src/components/homepage/LiveInputModules.astro
@@ -4,9 +4,15 @@ import type { HomepageLiveModule } from '../../data/homepageBoard';
 const { modules } = Astro.props as { modules: HomepageLiveModule[] };
 
 const toneClasses: Record<HomepageLiveModule['tone'], string> = {
-  high: 'border-rose-500/40 bg-rose-500/10',
-  medium: 'border-amber-400/30 bg-amber-300/5',
-  low: 'border-emerald-400/20 bg-white/5',
+  high: 'border-rose-400/25 bg-rose-400/[0.07]',
+  medium: 'border-amber-200/20 bg-amber-200/[0.05]',
+  low: 'border-emerald-200/15 bg-white/[0.035]',
+};
+
+const toneDotClasses: Record<HomepageLiveModule['tone'], string> = {
+  high: 'bg-rose-300',
+  medium: 'bg-amber-200',
+  low: 'bg-emerald-200',
 };
 ---
 
@@ -19,24 +25,30 @@ const toneClasses: Record<HomepageLiveModule['tone'], string> = {
     <p class="max-w-sm text-right text-xs leading-relaxed text-neutral-500">Framed honestly from recent STA publishing activity.</p>
   </div>
 
-  <div class="grid gap-4 md:grid-cols-2">
+  <div class="grid gap-4 md:grid-cols-2 2xl:grid-cols-4">
     {modules.map((module) => (
-      <article class={`rounded-2xl border p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)] ${toneClasses[module.tone]}`}>
+      <article class={`rounded-[1.6rem] border p-5 shadow-[0_18px_50px_-34px_rgba(0,0,0,0.75)] ${toneClasses[module.tone]}`}>
         <div class="space-y-3">
           <div class="flex items-start justify-between gap-4">
-            <p class="max-w-[15rem] text-sm font-semibold uppercase tracking-[0.18em] text-neutral-200">{module.title}</p>
-            <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-neutral-300">
+            <div class="space-y-2">
+              <div class="flex items-center gap-2">
+                <span class={`inline-block h-2 w-2 rounded-full ${toneDotClasses[module.tone]}`} aria-hidden="true"></span>
+                <p class="max-w-[15rem] text-[11px] font-semibold uppercase tracking-[0.24em] text-neutral-300">{module.title}</p>
+              </div>
+              <p class="text-3xl font-black tracking-tight text-white">{module.value}</p>
+            </div>
+            <span class="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">
               {module.value}
             </span>
           </div>
           <div class="space-y-2">
-            <p class="text-base font-semibold text-white">{module.summary}</p>
+            <p class="text-sm font-semibold uppercase tracking-[0.18em] text-neutral-100">{module.summary}</p>
             <p class="text-sm leading-relaxed text-neutral-400">{module.detail}</p>
           </div>
           {module.items && module.items.length > 0 && (
-            <ul class="space-y-1.5">
+            <ul class="flex flex-wrap gap-2">
               {module.items.map((item) => (
-                <li class="text-sm text-neutral-300">{item}</li>
+                <li class="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs font-medium text-neutral-300">{item}</li>
               ))}
             </ul>
           )}

--- a/src/components/homepage/MacroGauges.astro
+++ b/src/components/homepage/MacroGauges.astro
@@ -4,7 +4,7 @@ import type { HomepageMacroGauge } from '../../data/homepageBoard';
 const { gauges } = Astro.props as { gauges: HomepageMacroGauge[] };
 ---
 
-<section class="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-macro-gauges">
+<section class="rounded-[1.75rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-macro-gauges">
   <div class="space-y-1">
     <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Editorial macro gauges</p>
     <h3 class="text-xl font-black text-white">How the board reads the bigger picture</h3>
@@ -18,10 +18,12 @@ const { gauges } = Astro.props as { gauges: HomepageMacroGauge[] };
             <h4 class="text-base font-bold text-white">{gauge.title}</h4>
             <p class="text-sm leading-relaxed text-neutral-400">{gauge.summary}</p>
           </div>
-          <span class="text-2xl font-black tracking-tight text-white">{gauge.value}</span>
+          <span class="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-2xl font-black tracking-tight text-white">
+            {gauge.value}
+          </span>
         </div>
         <div class="h-2 rounded-full bg-white/10" aria-hidden="true">
-          <div class="h-2 rounded-full bg-gradient-to-r from-neutral-300 via-neutral-100 to-white" style={`width:${gauge.value}%`}></div>
+          <div class="h-2 rounded-full bg-gradient-to-r from-stone-400 via-stone-200 to-neutral-50" style={`width:${gauge.value}%`}></div>
         </div>
         <div class="flex items-start justify-between gap-4">
           <p class="max-w-sm text-sm leading-relaxed text-neutral-500">{gauge.detail}</p>

--- a/src/components/homepage/PressureRoom.astro
+++ b/src/components/homepage/PressureRoom.astro
@@ -11,35 +11,53 @@ const { board } = Astro.props as { board: HomepageBoardModel };
 ---
 
 <section
-  class="rounded-[2rem] border border-neutral-800 bg-neutral-950 px-5 py-6 text-white shadow-[0_28px_90px_-40px_rgba(0,0,0,0.75)] sm:px-6 sm:py-7 lg:px-8 lg:py-8"
+  class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(120,113,108,0.16),transparent_28%),radial-gradient(circle_at_top_right,rgba(120,113,108,0.08),transparent_26%),linear-gradient(180deg,rgba(16,16,18,0.98),rgba(5,5,6,1))] px-5 py-6 text-white shadow-[0_40px_120px_-48px_rgba(0,0,0,0.85)] sm:px-6 sm:py-7 lg:px-8 lg:py-8"
   data-testid="pressure-room-section"
 >
-  <div class="flex flex-col gap-4 border-b border-white/10 pb-6 lg:flex-row lg:items-end lg:justify-between">
-    <div class="max-w-3xl space-y-2">
-      <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-400">AI Pressure Room</p>
-      <h2 class="text-3xl font-black tracking-tight text-white sm:text-[2.4rem]">An editorial board surface for where AI pressure is building.</h2>
+  <div class="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:24px_24px] opacity-25" aria-hidden="true"></div>
+
+  <div class="relative flex flex-col gap-4 border-b border-white/10 pb-6 lg:flex-row lg:items-end lg:justify-between">
+    <div class="max-w-3xl space-y-3">
+      <div class="flex flex-wrap items-center gap-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">AI Pressure Room</p>
+        <span class="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-neutral-400">
+          Board-led homepage
+        </span>
+      </div>
+      <h2 class="text-3xl font-black tracking-tight text-white sm:text-[2.55rem]">The homepage now opens like a pressure board, not a magazine front page.</h2>
       <p class="text-base leading-relaxed text-neutral-300">
         Near-live modules summarize fresh STA coverage. Threat cards and macro gauges are explicit editorial judgments. Every route still
         leads back into posts, hubs, and methodology.
       </p>
     </div>
-    <div class="max-w-md rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm leading-relaxed text-neutral-300">
-      <p class="font-semibold text-white">Board timestamp: {board.anchorDateLabel}</p>
-      <p class="mt-1">This surface uses local config and recent publishing cadence first, so future API wiring has a clear seam.</p>
+    <div class="grid max-w-xl gap-3 sm:grid-cols-2">
+      <div class="rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm leading-relaxed text-neutral-300">
+        <p class="font-semibold text-white">Board timestamp: {board.anchorDateLabel}</p>
+        <p class="mt-1">Built from local config and recent publishing cadence first, so future API wiring has a clean seam.</p>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm leading-relaxed text-neutral-300">
+        <p class="font-semibold text-white">Signal contract</p>
+        <p class="mt-1">Near-live inputs are recent STA signals, not external real-time feeds.</p>
+      </div>
     </div>
   </div>
 
-  <div class="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
-    <div class="space-y-6">
-      <LiveInputModules modules={board.liveModules} />
-      <ThreatCardsBoard cards={board.threatCards} />
-    </div>
+  <div class="relative mt-6 space-y-6">
+    <LiveInputModules modules={board.liveModules} />
 
-    <div class="space-y-6">
-      <LeadDispatchCard post={board.leadPost} />
-      <MacroGauges gauges={board.macroGauges} />
-      <ImpactScoreFeed items={board.impactItems} />
-      <CommunityVote prompt={board.votePrompt} options={board.voteOptions} />
+    <div class="grid gap-6 xl:grid-cols-[minmax(0,1.18fr)_minmax(320px,0.82fr)]">
+      <div class="space-y-6">
+        <ThreatCardsBoard cards={board.threatCards} />
+      </div>
+
+      <div class="grid gap-6 xl:auto-rows-min">
+        <LeadDispatchCard post={board.leadPost} />
+        <div class="grid gap-6 lg:grid-cols-2 xl:grid-cols-1">
+          <MacroGauges gauges={board.macroGauges} />
+          <CommunityVote prompt={board.votePrompt} options={board.voteOptions} />
+        </div>
+        <ImpactScoreFeed items={board.impactItems} />
+      </div>
     </div>
   </div>
 </section>

--- a/src/components/homepage/ThreatCardsBoard.astro
+++ b/src/components/homepage/ThreatCardsBoard.astro
@@ -10,9 +10,9 @@ const { cards } = Astro.props as { cards: HomepageThreatCard[] };
     <h3 class="text-xl font-black text-white sm:text-2xl">Fear-area scores and weekly deltas</h3>
   </div>
 
-  <div class="grid gap-4 lg:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+  <div class="grid gap-4 lg:grid-cols-2">
     {cards.map((card) => (
-      <article class="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_16px_40px_-30px_rgba(0,0,0,0.65)]" data-testid="pressure-room-threat-card">
+      <article class="rounded-[1.75rem] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.025))] p-5 shadow-[0_22px_52px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-threat-card">
         <div class="flex items-start justify-between gap-4">
           <div class="space-y-2">
             <div class="flex items-center gap-3">
@@ -22,12 +22,16 @@ const { cards } = Astro.props as { cards: HomepageThreatCard[] };
             <h4 class="text-lg font-black text-white">{card.hub.shortName}</h4>
           </div>
           <div class="text-right">
-            <p class="text-3xl font-black tracking-tight text-white">{card.score}</p>
+            <p class="text-4xl font-black tracking-tight text-white">{card.score}</p>
             <p class={`text-xs font-semibold uppercase tracking-[0.18em] ${card.delta >= 0 ? 'text-amber-300' : 'text-emerald-300'}`}>
               {card.delta >= 0 ? '+' : ''}
               {card.delta} this week
             </p>
           </div>
+        </div>
+
+        <div class="mt-4 h-2 rounded-full bg-white/10" aria-hidden="true">
+          <div class="h-2 rounded-full" style={`width:${card.score}%;background:${card.hub.color};`}></div>
         </div>
 
         <div class="mt-4 space-y-2">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,158 +17,173 @@ const survivalAreas = [...SURVIVAL_HUBS].sort((a, b) => a.order - b.order);
 ---
 
 <Layout title="Survive the AI - Prepare, adapt, and stay ahead">
-  <main class="bg-[radial-gradient(circle_at_top,_rgba(23,23,23,0.06),_transparent_34%),linear-gradient(to_bottom,_#fafafa,_#f5f5f5_28%,_#ffffff_60%)] py-14 text-neutral-900 sm:py-18">
-    <div class="mx-auto max-w-screen-xl space-y-14 px-4 sm:px-6 lg:px-8">
-      <section class="py-2 sm:py-4" data-testid="homepage-hero">
-        <div class="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(280px,0.9fr)] lg:items-end">
-          <div class="space-y-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Survive the AI</p>
+  <main class="bg-[radial-gradient(circle_at_top,rgba(120,113,108,0.15),transparent_28%),radial-gradient(circle_at_20%_0%,rgba(255,255,255,0.06),transparent_20%),linear-gradient(180deg,#09090b_0%,#111113_34%,#0b0b0d_100%)] py-10 text-neutral-100 sm:py-14">
+    <div class="mx-auto max-w-screen-xl space-y-10 px-4 sm:px-6 lg:px-8">
+      <section class="py-2 sm:py-3" data-testid="homepage-hero">
+        <div class="grid gap-6 lg:grid-cols-[minmax(0,1.05fr)_minmax(300px,0.95fr)] lg:items-end">
+          <div class="space-y-5">
+            <div class="flex flex-wrap items-center gap-2">
+              <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Survive the AI</p>
+              <span class="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-neutral-400">
+                Editorial pressure board
+              </span>
+            </div>
             <div class="max-w-4xl space-y-4">
-              <h1 class="text-3xl font-black leading-[1.02] tracking-tight text-neutral-950 sm:text-[2.8rem] lg:text-[3.7rem]">
-                The pressure is no longer theoretical. Track where AI is pressing first.
+              <h1 class="text-3xl font-black leading-[1.01] tracking-tight text-white sm:text-[2.9rem] lg:text-[4rem]">
+                The pressure is no longer theoretical. Start with the board.
               </h1>
-              <p class="max-w-3xl text-base leading-relaxed text-neutral-600 sm:text-lg">
+              <p class="max-w-3xl text-base leading-relaxed text-neutral-300 sm:text-lg">
                 SurviveTheAI is an editorial survival guide for people navigating AI pressure across work, school, relationships, attention,
-                and institutions. The homepage now opens with the board: what STA is seeing, how the editor scores it, and where to read
-                deeper next.
+                and institutions. The homepage now frames the site as a live board first, then routes you deeper into reporting,
+                methodology, and fear-area hubs.
               </p>
             </div>
           </div>
-          <div class="rounded-3xl border border-neutral-200 bg-white/90 p-6 shadow-[0_18px_48px_-36px_rgba(0,0,0,0.35)] backdrop-blur">
-            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">How to use the board</p>
-            <ul class="mt-4 space-y-3 text-sm leading-relaxed text-neutral-700">
-              <li>Read the near-live modules as recent signal summaries, not real-time feeds.</li>
-              <li>Treat the threat cards and gauges as clearly labeled editorial judgment.</li>
-              <li>Use the impact feed, fear areas, and Start Here path to route into full reporting.</li>
-            </ul>
+          <div class="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+            <div class="rounded-[1.65rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_18px_52px_-36px_rgba(0,0,0,0.75)]">
+              <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">Read honestly</p>
+              <p class="mt-3 text-sm leading-relaxed text-neutral-300">Near-live modules summarize recent STA publishing activity. They are not real-time feeds.</p>
+            </div>
+            <div class="rounded-[1.65rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_18px_52px_-36px_rgba(0,0,0,0.75)]">
+              <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">Score clearly</p>
+              <p class="mt-3 text-sm leading-relaxed text-neutral-300">Threat cards and macro gauges are labeled editorial judgment, not synthetic certainty.</p>
+            </div>
+            <div class="rounded-[1.65rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_18px_52px_-36px_rgba(0,0,0,0.75)]">
+              <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">Route deeper</p>
+              <p class="mt-3 text-sm leading-relaxed text-neutral-300">Use the board to enter Start Here, fear-area hubs, posts, and standards without losing context.</p>
+            </div>
           </div>
         </div>
       </section>
 
       <PressureRoom board={board} />
 
-      {editorPicks.length > 0 && (
-        <section class="space-y-6" data-testid="start-here-section">
-          <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-            <div class="max-w-3xl space-y-1">
-              <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Start Here / Editor's Picks</p>
-              <h2 class="text-2xl font-black text-neutral-950 sm:text-3xl">Use the board, then take the guided path</h2>
-              <p class="text-neutral-600">
-                New readers should map the pressure first, then use Start Here and these editor-selected posts to understand the site’s
-                logic.
+      <div class="space-y-8 rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,21,0.96),rgba(10,10,12,0.99))] px-5 py-6 shadow-[0_32px_90px_-52px_rgba(0,0,0,0.8)] sm:px-6 sm:py-7 lg:px-8 lg:py-8">
+        {editorPicks.length > 0 && (
+          <section class="space-y-6" data-testid="start-here-section">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div class="max-w-3xl space-y-1">
+                <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Start Here / Editor's Picks</p>
+                <h2 class="text-2xl font-black text-white sm:text-3xl">Use the board, then take the guided path</h2>
+                <p class="text-neutral-300">
+                  New readers should map the pressure first, then use Start Here and these editor-selected posts to understand the site's
+                  logic.
+                </p>
+              </div>
+              <div class="flex flex-wrap gap-3">
+                <a
+                  href="/start-here"
+                  class="inline-flex items-center justify-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/35"
+                  data-testid="start-here-guided-link"
+                  data-analytics-event="start_here_entry_click"
+                  data-analytics-location="homepage-start-here-section"
+                  data-analytics-label="Open the guided path"
+                >
+                  Open the guided path
+                </a>
+                <a
+                  href="/posts"
+                  class="inline-flex items-center justify-center rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
+                >
+                  Explore the full library
+                </a>
+              </div>
+            </div>
+            <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+              {editorPicks.map((post) => (
+                <PostCard post={post} variant="board" />
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section class="space-y-6" data-testid="survival-areas-section">
+          <div class="space-y-1">
+            <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Fear Areas</p>
+            <h2 class="text-2xl font-black text-white sm:text-3xl">Route by fear area</h2>
+            <p class="max-w-3xl text-neutral-300">
+              The board condenses the pressure. The fear-area hubs hold the ongoing reporting, practical framing, and deeper archive for
+              each zone.
+            </p>
+          </div>
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
+            {survivalAreas.map((area) => (
+              <a
+                href={`${area.slug}/`}
+                class="group flex h-full flex-col justify-between gap-4 rounded-[1.6rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_18px_44px_-34px_rgba(0,0,0,0.75)] transition hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/25"
+                data-testid="survival-area-tile"
+              >
+                <div class="space-y-3">
+                  <div class="flex items-center gap-3">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full" style={`background:${area.color}`} aria-hidden="true" />
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">Fear area</p>
+                  </div>
+                  <h3 class="text-lg font-black leading-tight text-white transition group-hover:text-neutral-200">{area.shortName}</h3>
+                  <p class="text-sm leading-relaxed text-neutral-300">{area.tagline}</p>
+                </div>
+                <span class="text-sm font-semibold text-white">Open the hub</span>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <PlaybookOffer
+          eyebrow="Reader offer"
+          title="Get the free Survival Playbook before the pressure gets personal"
+          description="If you want one clear next-step resource, use the playbook. It pulls together STA's practical checklists without turning the homepage into a funnel."
+          href="/playbook"
+          ctaLabel="Get the free playbook"
+          secondaryHref="/start-here"
+          secondaryLabel="Open Start Here"
+          disclaimer="Free reader resource. Intentional placement, not constant interruption."
+          testId="homepage-playbook-offer"
+          variant="board"
+          primaryAnalyticsEvent="playbook_cta_click"
+          primaryAnalyticsLocation="homepage-playbook-offer"
+          secondaryAnalyticsEvent="start_here_entry_click"
+          secondaryAnalyticsLocation="homepage-playbook-offer"
+        />
+
+        <section class="space-y-6" data-testid="homepage-subscribe">
+          <SubscribeInline
+            client:load
+            location="home"
+            heading="Get the weekly briefing"
+            helperText="One concise weekly email with the newest signal, what it means, and where to act next."
+            privacyText="Free. No spam. Unsubscribe anytime."
+            variant="board"
+          />
+        </section>
+
+        <CredibilityPanel eyebrow="Why trust STA" title="Named reporting, visible standards, clear ownership" variant="board" />
+
+        {remaining.length > 0 && (
+          <section class="space-y-5" data-testid="library-cta-section">
+            <div class="space-y-1">
+              <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Library / Archive</p>
+              <h2 class="text-2xl font-black text-white sm:text-3xl">Keep moving through the reporting</h2>
+              <p class="max-w-3xl text-neutral-300">
+                The homepage board is the front door, not the whole system. The full library is where the longer survival map keeps
+                filling in.
               </p>
             </div>
             <div class="flex flex-wrap gap-3">
               <a
-                href="/start-here"
-                class="inline-flex items-center justify-center rounded-full bg-neutral-950 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
-                data-testid="start-here-guided-link"
-                data-analytics-event="start_here_entry_click"
-                data-analytics-location="homepage-start-here-section"
-                data-analytics-label="Open the guided path"
+                href="/posts"
+                class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/35"
               >
-                Open the guided path
+                Go to the Survival Library
               </a>
               <a
-                href="/posts"
-                class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
+                href="/impact-score-methodology"
+                class="inline-flex items-center justify-center rounded-full border border-white/15 px-6 py-3 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
               >
-                Explore the full library
+                Read the Impact Score methodology
               </a>
             </div>
-          </div>
-          <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
-            {editorPicks.map((post) => (
-              <PostCard post={post} />
-            ))}
-          </div>
-        </section>
-      )}
-
-      <section class="space-y-6" data-testid="survival-areas-section">
-        <div class="space-y-1">
-          <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Fear Areas</p>
-          <h2 class="text-2xl font-black text-neutral-950 sm:text-3xl">Route by fear area</h2>
-          <p class="max-w-3xl text-neutral-600">
-            The board condenses the pressure. The fear-area hubs hold the ongoing reporting, practical framing, and deeper archive for each
-            zone.
-          </p>
-        </div>
-        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
-          {survivalAreas.map((area) => (
-            <a
-              href={`${area.slug}/`}
-              class="group flex h-full flex-col justify-between gap-4 rounded-2xl border border-neutral-200 bg-white p-5 shadow-[0_16px_40px_-34px_rgba(0,0,0,0.35)] transition hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-[0_20px_48px_-32px_rgba(0,0,0,0.42)] focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400"
-              data-testid="survival-area-tile"
-            >
-              <div class="space-y-3">
-                <div class="flex items-center gap-3">
-                  <span class="inline-block h-2.5 w-2.5 rounded-full" style={`background:${area.color}`} aria-hidden="true" />
-                  <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">Fear area</p>
-                </div>
-                <h3 class="text-lg font-black leading-tight text-neutral-900 transition group-hover:text-neutral-700">{area.shortName}</h3>
-                <p class="text-sm leading-relaxed text-neutral-600">{area.tagline}</p>
-              </div>
-              <span class="text-sm font-semibold text-neutral-900">Open the hub</span>
-            </a>
-          ))}
-        </div>
-      </section>
-
-      <PlaybookOffer
-        eyebrow="Reader offer"
-        title="Get the free Survival Playbook before the pressure gets personal"
-        description="If you want one clear next-step resource, use the playbook. It pulls together STA's practical checklists without turning the homepage into a funnel."
-        href="/playbook"
-        ctaLabel="Get the free playbook"
-        secondaryHref="/start-here"
-        secondaryLabel="Open Start Here"
-        disclaimer="Free reader resource. Intentional placement, not constant interruption."
-        testId="homepage-playbook-offer"
-        primaryAnalyticsEvent="playbook_cta_click"
-        primaryAnalyticsLocation="homepage-playbook-offer"
-        secondaryAnalyticsEvent="start_here_entry_click"
-        secondaryAnalyticsLocation="homepage-playbook-offer"
-      />
-
-      <section class="space-y-6" data-testid="homepage-subscribe">
-        <SubscribeInline
-          client:load
-          location="home"
-          heading="Get the weekly briefing"
-          helperText="One concise weekly email with the newest signal, what it means, and where to act next."
-          privacyText="Free. No spam. Unsubscribe anytime."
-        />
-      </section>
-
-      <CredibilityPanel eyebrow="Why trust STA" title="Named reporting, visible standards, clear ownership" />
-
-      {remaining.length > 0 && (
-        <section class="space-y-5" data-testid="library-cta-section">
-          <div class="space-y-1">
-            <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Library / Archive</p>
-            <h2 class="text-2xl font-black text-neutral-950 sm:text-3xl">Keep moving through the reporting</h2>
-            <p class="max-w-3xl text-neutral-600">
-              The homepage board is the front door, not the whole system. The full library is where the longer survival map keeps filling
-              in.
-            </p>
-          </div>
-          <div class="flex flex-wrap gap-3">
-            <a
-              href="/posts"
-              class="inline-flex items-center justify-center rounded-full bg-neutral-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
-            >
-              Go to the Survival Library
-            </a>
-            <a
-              href="/impact-score-methodology"
-              class="inline-flex items-center justify-center rounded-full border border-neutral-300 px-6 py-3 text-sm font-semibold text-neutral-900 transition hover:border-neutral-500 hover:text-neutral-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-700"
-            >
-              Read the Impact Score methodology
-            </a>
-          </div>
-        </section>
-      )}
+          </section>
+        )}
+      </div>
     </div>
   </main>
 </Layout>

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -39,13 +39,7 @@ test.describe('Homepage layout', () => {
   test('homepage section order stays locked and intentional', async ({ page }) => {
     await page.goto('/');
 
-    const sectionOrder = await page.locator('main > div').evaluate((container) =>
-      Array.from(container.children)
-        .map((node) => node.getAttribute('data-testid'))
-        .filter(Boolean),
-    );
-
-    expect(sectionOrder).toEqual([
+    const expectedOrder = [
       'homepage-hero',
       'pressure-room-section',
       'start-here-section',
@@ -54,7 +48,16 @@ test.describe('Homepage layout', () => {
       'homepage-subscribe',
       'credibility-panel',
       'library-cta-section',
-    ]);
+    ];
+
+    const sectionOrder = await page.locator('main [data-testid]').evaluateAll((nodes, ids) => {
+      const expectedIds = new Set(ids as string[]);
+      return nodes
+        .map((node) => node.getAttribute('data-testid'))
+        .filter((value): value is string => Boolean(value) && expectedIds.has(value));
+    }, expectedOrder);
+
+    expect(sectionOrder).toEqual(expectedOrder);
   });
 
   test('pressure room keeps its honest data separation and routes back into reporting', async ({ page }) => {


### PR DESCRIPTION
## What changed visually
- shortened the homepage framing hero and shifted the visual center of gravity immediately into the pressure board
- rebuilt the homepage shell around a darker charcoal board-led system so the board no longer feels like a dark module dropped into a light editorial page
- tightened the internal board composition so the live modules occupy the top zone, the threat cards read as the main board surface, and the lead dispatch, gauges, impact feed, and vote widget share one integrated right-rail system
- introduced opt-in board variants for the supporting homepage cards, playbook offer, subscribe block, and credibility panel so the supporting sections stay visually inside the same ecosystem
- softened borders, reduced loud saturation, and kept accents functional through chips, bars, deltas, and category markers

## How this better matches the intended board-led homepage
- the homepage now reads as a board-first experience immediately after a short framing intro instead of a mostly standard editorial page with one dark insert
- the board visually dominates the page and carries the mood, hierarchy, and composition deeper into the support sections
- supporting sections now feel like deliberate extensions of the board rather than competing white blocks
- the honest separation between near-live signals, editorial scoring, and local-browser voting remains explicit in the copy and structure

## Validation
- 
pm run build
- 
pm.cmd test -- tests/homepage.spec.ts

## Future work
- finer visual tuning against the approved canvas once there is side-by-side design review feedback on exact density, spacing, and typography choices
- any future API-backed live data or shared vote persistence once real back-end seams are approved
- any broader site-wide theming decisions beyond the homepage-specific board alignment completed here