### PR TITLE
Homepage step 1: separate widget and editorial card families

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -17,12 +17,12 @@ const imageAlt = post.data.heroImageAlt ?? post.data.title;
   class:list={[
     'group flex h-full flex-col overflow-hidden rounded-3xl transition focus:outline-none focus-visible:ring-2',
     variant === 'board'
-      ? 'border border-white/10 bg-neutral-950/85 shadow-[0_24px_60px_-38px_rgba(0,0,0,0.8)] hover:-translate-y-1 hover:border-white/20 hover:bg-neutral-950 focus-visible:ring-white/30'
+      ? 'border border-slate-700/70 bg-[linear-gradient(180deg,rgba(37,42,49,0.98),rgba(22,26,31,0.98))] shadow-[0_24px_60px_-38px_rgba(0,0,0,0.84)] hover:-translate-y-1 hover:border-slate-500/80 hover:bg-[linear-gradient(180deg,rgba(41,46,54,0.99),rgba(24,28,34,0.99))] focus-visible:ring-white/30'
       : 'border border-neutral-200 bg-white shadow-sm hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-md focus-visible:ring-neutral-400',
   ]}
   data-testid="post-card"
 >
-  <div class:list={['relative aspect-[16/9] overflow-hidden', variant === 'board' ? 'bg-neutral-900' : 'bg-neutral-100']}>
+  <div class:list={['relative aspect-[16/9] overflow-hidden', variant === 'board' ? 'bg-slate-900' : 'bg-neutral-100']}>
     <img
       src={imageSrc}
       alt={imageAlt}
@@ -39,16 +39,16 @@ const imageAlt = post.data.heroImageAlt ?? post.data.title;
       <h3
         class:list={[
           'text-xl font-bold leading-tight line-clamp-2 transition',
-          variant === 'board' ? 'text-white group-hover:text-neutral-200' : 'text-neutral-900 group-hover:text-neutral-700',
+          variant === 'board' ? 'text-stone-100 group-hover:text-white' : 'text-neutral-900 group-hover:text-neutral-700',
         ]}
       >
         {post.data.title}
       </h3>
-      <p class:list={['text-sm leading-relaxed line-clamp-3', variant === 'board' ? 'text-neutral-300' : 'text-neutral-600']}>
+      <p class:list={['text-sm leading-relaxed line-clamp-3', variant === 'board' ? 'text-slate-300' : 'text-neutral-600']}>
         {post.data.description}
       </p>
     </div>
-    <div class:list={['mt-auto pt-4', variant === 'board' ? 'border-t border-white/10' : 'border-t border-neutral-100']}>
+    <div class:list={['mt-auto pt-4', variant === 'board' ? 'border-t border-slate-700/80' : 'border-t border-neutral-100']}>
       <PostCardMeta post={post} compact={false} showImpact={true} variant={variant} />
     </div>
   </div>

--- a/src/components/PostCardMeta.astro
+++ b/src/components/PostCardMeta.astro
@@ -19,20 +19,20 @@ const authorLabel = getAuthorProfile(post.data.author).displayName;
 const metaClass =
   variant === 'board'
     ? compact
-      ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
-      : 'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-400'
+      ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.28em] text-slate-400'
+      : 'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-slate-400'
     : compact
       ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
       : 'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500';
 const impactClass =
   variant === 'board'
     ? compact
-      ? 'text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-400'
-      : 'text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-300'
+      ? 'text-[9px] font-semibold uppercase tracking-[0.28em] text-slate-300'
+      : 'text-[10px] font-semibold uppercase tracking-[0.32em] text-slate-300'
     : compact
       ? 'text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
       : 'text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500';
-const dividerClass = variant === 'board' ? 'h-1 w-1 rounded-full bg-white/15' : 'h-1 w-1 rounded-full bg-neutral-300';
+const dividerClass = variant === 'board' ? 'h-1 w-1 rounded-full bg-slate-500/60' : 'h-1 w-1 rounded-full bg-neutral-300';
 ---
 
 {showImpact ? (

--- a/src/components/homepage/CommunityVote.astro
+++ b/src/components/homepage/CommunityVote.astro
@@ -7,11 +7,11 @@ const { prompt, options } = Astro.props as {
 };
 ---
 
-<section class="rounded-[1.75rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-vote" data-vote-widget>
+<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-vote" data-vote-widget>
   <div class="space-y-1">
-    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Community vote</p>
-    <h3 class="text-xl font-black text-white">{prompt}</h3>
-    <p class="text-sm leading-relaxed text-neutral-400">
+    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-500">Community vote</p>
+    <h3 class="text-xl font-black text-stone-950">{prompt}</h3>
+    <p class="text-sm leading-relaxed text-stone-600">
       Local browser vote for now. This widget stores only your selection on this device until a sitewide API exists.
     </p>
   </div>
@@ -20,22 +20,22 @@ const { prompt, options } = Astro.props as {
     {options.map((option) => (
       <button
         type="button"
-        class="vote-option flex items-start justify-between gap-4 rounded-[1.35rem] border border-white/10 bg-black/15 px-4 py-3 text-left transition hover:border-white/20 hover:bg-white/[0.07]"
+        class="vote-option flex items-start justify-between gap-4 rounded-[1.35rem] border border-stone-200 bg-white/70 px-4 py-3 text-left transition hover:border-stone-300 hover:bg-white"
         data-vote-option
         data-option-id={option.id}
       >
         <span class="space-y-1">
-          <span class="block text-sm font-semibold text-white">{option.label}</span>
-          <span class="block text-sm leading-relaxed text-neutral-400">{option.description}</span>
+          <span class="block text-sm font-semibold text-stone-950">{option.label}</span>
+          <span class="block text-sm leading-relaxed text-stone-600">{option.description}</span>
         </span>
-        <span class="vote-pill mt-0.5 rounded-full border border-white/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">
+        <span class="vote-pill mt-0.5 rounded-full border border-stone-300 bg-stone-100 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-600">
           Vote
         </span>
       </button>
     ))}
   </div>
 
-  <p class="mt-4 text-sm font-semibold text-neutral-300" data-vote-status>Choose one fear area to save your local vote.</p>
+  <p class="mt-4 text-sm font-semibold text-stone-700" data-vote-status>Choose one fear area to save your local vote.</p>
 </section>
 
 <script is:inline>
@@ -52,13 +52,14 @@ const { prompt, options } = Astro.props as {
         if (!(button instanceof HTMLElement)) return;
         const active = button.dataset.optionId === selectedId;
         button.setAttribute('aria-pressed', active ? 'true' : 'false');
-        button.classList.toggle('border-white/40', active);
-        button.classList.toggle('bg-white/[0.08]', active);
+        button.classList.toggle('border-stone-500', active);
+        button.classList.toggle('bg-stone-100', active);
         const pill = button.querySelector('.vote-pill');
         if (pill instanceof HTMLElement) {
           pill.textContent = active ? 'Saved' : 'Vote';
-          pill.classList.toggle('text-white', active);
-          pill.classList.toggle('border-white/30', active);
+          pill.classList.toggle('text-stone-950', active);
+          pill.classList.toggle('border-stone-500', active);
+          pill.classList.toggle('bg-white', active);
         }
       });
 

--- a/src/components/homepage/ImpactScoreFeed.astro
+++ b/src/components/homepage/ImpactScoreFeed.astro
@@ -8,13 +8,13 @@ const { items } = Astro.props as { items: PostEntry[] };
 const categoryByKey = new Map(TOPIC_CATEGORIES.map((category) => [category.key, category]));
 ---
 
-<section class="rounded-[1.75rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-impact-feed">
+<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-impact-feed">
   <div class="flex items-end justify-between gap-4">
     <div class="space-y-1">
-      <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Latest impact score items</p>
-      <h3 class="text-xl font-black text-white">Route into the newest reporting</h3>
+      <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-500">Latest impact score items</p>
+      <h3 class="text-xl font-black text-stone-950">Route into the newest reporting</h3>
     </div>
-    <a href="/posts" class="text-sm font-semibold text-neutral-200 underline decoration-white/20 underline-offset-4 transition hover:text-white">
+    <a href="/posts" class="text-sm font-semibold text-stone-700 underline decoration-stone-300 underline-offset-4 transition hover:text-stone-950">
       Full archive
     </a>
   </div>
@@ -26,23 +26,23 @@ const categoryByKey = new Map(TOPIC_CATEGORIES.map((category) => [category.key, 
       return (
         <a
           href={`/posts/${post.slug}/`}
-          class="flex flex-col gap-4 rounded-[1.35rem] border border-white/10 bg-black/15 p-4 transition hover:border-white/20 hover:bg-white/[0.07] sm:flex-row sm:items-center sm:justify-between"
+          class="flex flex-col gap-4 rounded-[1.35rem] border border-stone-200 bg-white/70 p-4 transition hover:border-stone-300 hover:bg-white sm:flex-row sm:items-center sm:justify-between"
           data-testid="pressure-room-impact-item"
         >
           <div class="space-y-2">
-            <div class="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-400">
+            <div class="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
               <span>{category?.label ?? post.data.category ?? 'Key topic'}</span>
-              <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-600" />
+              <span aria-hidden class="h-1 w-1 rounded-full bg-stone-300" />
               <span>{formatDate(post.data.date)}</span>
             </div>
-            <h4 class="text-base font-bold leading-tight text-white">{post.data.title}</h4>
-            <p class="text-sm leading-relaxed text-neutral-400">{post.data.description}</p>
+            <h4 class="text-base font-bold leading-tight text-stone-950">{post.data.title}</h4>
+            <p class="text-sm leading-relaxed text-stone-600">{post.data.description}</p>
           </div>
           <div class="flex flex-none items-center gap-3 sm:flex-col sm:items-end">
-            <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-200">
+            <span class="rounded-full border border-stone-300 bg-stone-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-stone-700">
               Impact {post.data.impact_score}
             </span>
-            <span class="text-sm font-semibold text-neutral-200">Read post</span>
+            <span class="text-sm font-semibold text-stone-700">Read post</span>
           </div>
         </a>
       );

--- a/src/components/homepage/LiveInputModules.astro
+++ b/src/components/homepage/LiveInputModules.astro
@@ -4,15 +4,15 @@ import type { HomepageLiveModule } from '../../data/homepageBoard';
 const { modules } = Astro.props as { modules: HomepageLiveModule[] };
 
 const toneClasses: Record<HomepageLiveModule['tone'], string> = {
-  high: 'border-rose-400/25 bg-rose-400/[0.07]',
-  medium: 'border-amber-200/20 bg-amber-200/[0.05]',
-  low: 'border-emerald-200/15 bg-white/[0.035]',
+  high: 'border-rose-200 bg-[linear-gradient(180deg,rgba(255,241,242,0.98),rgba(255,247,237,0.94))]',
+  medium: 'border-amber-200 bg-[linear-gradient(180deg,rgba(255,251,235,0.98),rgba(250,250,249,0.94))]',
+  low: 'border-emerald-200 bg-[linear-gradient(180deg,rgba(240,253,244,0.98),rgba(250,250,249,0.94))]',
 };
 
 const toneDotClasses: Record<HomepageLiveModule['tone'], string> = {
-  high: 'bg-rose-300',
-  medium: 'bg-amber-200',
-  low: 'bg-emerald-200',
+  high: 'bg-rose-500',
+  medium: 'bg-amber-500',
+  low: 'bg-emerald-500',
 };
 ---
 
@@ -33,30 +33,30 @@ const toneDotClasses: Record<HomepageLiveModule['tone'], string> = {
             <div class="space-y-2">
               <div class="flex items-center gap-2">
                 <span class={`inline-block h-2 w-2 rounded-full ${toneDotClasses[module.tone]}`} aria-hidden="true"></span>
-                <p class="max-w-[15rem] text-[11px] font-semibold uppercase tracking-[0.24em] text-neutral-300">{module.title}</p>
+                <p class="max-w-[15rem] text-[11px] font-semibold uppercase tracking-[0.24em] text-stone-500">{module.title}</p>
               </div>
-              <p class="text-3xl font-black tracking-tight text-white">{module.value}</p>
+              <p class="text-3xl font-black tracking-tight text-stone-950">{module.value}</p>
             </div>
-            <span class="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">
+            <span class="rounded-full border border-stone-300 bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-600">
               {module.value}
             </span>
           </div>
           <div class="space-y-2">
-            <p class="text-sm font-semibold uppercase tracking-[0.18em] text-neutral-100">{module.summary}</p>
-            <p class="text-sm leading-relaxed text-neutral-400">{module.detail}</p>
+            <p class="text-sm font-semibold uppercase tracking-[0.18em] text-stone-900">{module.summary}</p>
+            <p class="text-sm leading-relaxed text-stone-600">{module.detail}</p>
           </div>
           {module.items && module.items.length > 0 && (
             <ul class="flex flex-wrap gap-2">
               {module.items.map((item) => (
-                <li class="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs font-medium text-neutral-300">{item}</li>
+                <li class="rounded-full border border-stone-200 bg-white/75 px-3 py-1 text-xs font-medium text-stone-700">{item}</li>
               ))}
             </ul>
           )}
         </div>
-        <div class="mt-4 flex items-center justify-between gap-4 border-t border-white/10 pt-4">
-          <p class="max-w-xs text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-500">{module.sourceLabel}</p>
+        <div class="mt-4 flex items-center justify-between gap-4 border-t border-stone-200 pt-4">
+          <p class="max-w-xs text-[11px] font-medium uppercase tracking-[0.18em] text-stone-500">{module.sourceLabel}</p>
           {module.href && module.hrefLabel && (
-            <a href={module.href} class="text-sm font-semibold text-neutral-100 underline decoration-white/20 underline-offset-4 transition hover:text-white">
+            <a href={module.href} class="text-sm font-semibold text-stone-700 underline decoration-stone-300 underline-offset-4 transition hover:text-stone-950">
               {module.hrefLabel}
             </a>
           )}

--- a/src/components/homepage/MacroGauges.astro
+++ b/src/components/homepage/MacroGauges.astro
@@ -4,10 +4,10 @@ import type { HomepageMacroGauge } from '../../data/homepageBoard';
 const { gauges } = Astro.props as { gauges: HomepageMacroGauge[] };
 ---
 
-<section class="rounded-[1.75rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-macro-gauges">
+<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-macro-gauges">
   <div class="space-y-1">
-    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Editorial macro gauges</p>
-    <h3 class="text-xl font-black text-white">How the bigger picture looks from here</h3>
+    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-500">Editorial macro gauges</p>
+    <h3 class="text-xl font-black text-stone-950">How the bigger picture looks from here</h3>
   </div>
 
   <div class="mt-5 space-y-5">
@@ -15,19 +15,19 @@ const { gauges } = Astro.props as { gauges: HomepageMacroGauge[] };
       <article class="space-y-2">
         <div class="flex items-end justify-between gap-4">
           <div class="space-y-1">
-            <h4 class="text-base font-bold text-white">{gauge.title}</h4>
-            <p class="text-sm leading-relaxed text-neutral-400">{gauge.summary}</p>
+            <h4 class="text-base font-bold text-stone-950">{gauge.title}</h4>
+            <p class="text-sm leading-relaxed text-stone-600">{gauge.summary}</p>
           </div>
-          <span class="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-2xl font-black tracking-tight text-white">
+          <span class="rounded-full border border-stone-300 bg-white/80 px-3 py-1 text-2xl font-black tracking-tight text-stone-950">
             {gauge.value}
           </span>
         </div>
-        <div class="h-2 rounded-full bg-white/10" aria-hidden="true">
+        <div class="h-2 rounded-full bg-stone-200" aria-hidden="true">
           <div class="h-2 rounded-full bg-gradient-to-r from-stone-400 via-stone-200 to-neutral-50" style={`width:${gauge.value}%`}></div>
         </div>
         <div class="flex items-start justify-between gap-4">
-          <p class="max-w-sm text-sm leading-relaxed text-neutral-500">{gauge.detail}</p>
-          <a href={gauge.href} class="text-sm font-semibold text-neutral-200 underline decoration-white/20 underline-offset-4 transition hover:text-white">
+          <p class="max-w-sm text-sm leading-relaxed text-stone-500">{gauge.detail}</p>
+          <a href={gauge.href} class="text-sm font-semibold text-stone-700 underline decoration-stone-300 underline-offset-4 transition hover:text-stone-950">
             {gauge.hrefLabel}
           </a>
         </div>

--- a/src/components/homepage/PressureRoom.astro
+++ b/src/components/homepage/PressureRoom.astro
@@ -27,12 +27,12 @@ const { board } = Astro.props as { board: HomepageBoardModel };
       </p>
     </div>
     <div class="grid max-w-xl gap-3 sm:grid-cols-2">
-      <div class="rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm leading-relaxed text-neutral-300">
-        <p class="font-semibold text-white">Updated through {board.anchorDateLabel}</p>
+      <div class="rounded-2xl border border-stone-200/80 bg-stone-50/95 px-4 py-3 text-sm leading-relaxed text-stone-600 shadow-[0_18px_40px_-34px_rgba(0,0,0,0.6)]">
+        <p class="font-semibold text-stone-950">Updated through {board.anchorDateLabel}</p>
         <p class="mt-1">Recent STA coverage sets the pace for what shows up here first.</p>
       </div>
-      <div class="rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm leading-relaxed text-neutral-300">
-        <p class="font-semibold text-white">Read it cleanly</p>
+      <div class="rounded-2xl border border-stone-200/80 bg-stone-50/95 px-4 py-3 text-sm leading-relaxed text-stone-600 shadow-[0_18px_40px_-34px_rgba(0,0,0,0.6)]">
+        <p class="font-semibold text-stone-950">Read it cleanly</p>
         <p class="mt-1">Near-live signals track recent coverage. Scores and gauges are editorial judgment.</p>
       </div>
     </div>

--- a/src/components/homepage/ThreatCardsBoard.astro
+++ b/src/components/homepage/ThreatCardsBoard.astro
@@ -12,44 +12,44 @@ const { cards } = Astro.props as { cards: HomepageThreatCard[] };
 
   <div class="grid gap-4 lg:grid-cols-2">
     {cards.map((card) => (
-      <article class="rounded-[1.75rem] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.025))] p-5 shadow-[0_22px_52px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-threat-card">
+      <article class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_22px_52px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-threat-card">
         <div class="flex items-start justify-between gap-4">
           <div class="space-y-2">
             <div class="flex items-center gap-3">
               <span class="inline-block h-2.5 w-2.5 rounded-full" style={`background:${card.hub.color}`} aria-hidden="true" />
-              <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-400">Editorial score</p>
+              <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-stone-500">Editorial score</p>
             </div>
-            <h4 class="text-lg font-black text-white">{card.hub.shortName}</h4>
+            <h4 class="text-lg font-black text-stone-950">{card.hub.shortName}</h4>
           </div>
           <div class="text-right">
-            <p class="text-4xl font-black tracking-tight text-white">{card.score}</p>
-            <p class={`text-xs font-semibold uppercase tracking-[0.18em] ${card.delta >= 0 ? 'text-amber-300' : 'text-emerald-300'}`}>
+            <p class="text-4xl font-black tracking-tight text-stone-950">{card.score}</p>
+            <p class={`text-xs font-semibold uppercase tracking-[0.18em] ${card.delta >= 0 ? 'text-amber-700' : 'text-emerald-700'}`}>
               {card.delta >= 0 ? '+' : ''}
               {card.delta} this week
             </p>
           </div>
         </div>
 
-        <div class="mt-4 h-2 rounded-full bg-white/10" aria-hidden="true">
+        <div class="mt-4 h-2 rounded-full bg-stone-200" aria-hidden="true">
           <div class="h-2 rounded-full" style={`width:${card.score}%;background:${card.hub.color};`}></div>
         </div>
 
         <div class="mt-4 space-y-2">
-          <p class="text-sm font-semibold leading-relaxed text-neutral-100">{card.stance}</p>
-          <p class="text-sm leading-relaxed text-neutral-400">{card.summary}</p>
+          <p class="text-sm font-semibold leading-relaxed text-stone-900">{card.stance}</p>
+          <p class="text-sm leading-relaxed text-stone-600">{card.summary}</p>
         </div>
 
-        <div class="mt-5 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4">
+        <div class="mt-5 flex flex-wrap items-center gap-3 border-t border-stone-200 pt-4">
           <a
             href={`${card.hub.slug}/`}
-            class="inline-flex items-center justify-center rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/5"
+            class="inline-flex items-center justify-center rounded-full border border-stone-300 bg-white/70 px-4 py-2 text-sm font-semibold text-stone-950 transition hover:border-stone-400 hover:bg-white"
           >
             Open {card.hub.shortName}
           </a>
           {card.latestPost && (
             <a
               href={`/posts/${card.latestPost.slug}/`}
-              class="text-sm font-semibold text-neutral-200 underline decoration-white/20 underline-offset-4 transition hover:text-white"
+              class="text-sm font-semibold text-stone-700 underline decoration-stone-300 underline-offset-4 transition hover:text-stone-950"
             >
               Latest dispatch
             </a>


### PR DESCRIPTION
## Summary
- move Pressure Room scan widgets to warm light cards with dark text
- keep homepage editorial post cards on a darker graphite treatment
- leave broader utility and conversion blocks unchanged in this pass

## Validation
- `npm run build`
- `npx playwright test tests/homepage.spec.ts` *(blocked in sandbox: local Astro web server could not bind to `0.0.0.0:4321` due `EPERM`)*