### PR TITLE
Homepage step 3: spacing and typography polish

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -33,22 +33,22 @@ const imageAlt = post.data.heroImageAlt ?? post.data.title;
       class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
     />
   </div>
-  <div class="flex flex-1 flex-col gap-5 p-5 sm:p-6">
-    <div class="space-y-3">
+  <div class="flex flex-1 flex-col gap-6 p-5 sm:p-6 lg:p-[1.625rem]">
+    <div class="space-y-3.5">
       <PostCardMeta post={post} variant={variant} />
       <h3
         class:list={[
-          'text-xl font-bold leading-tight line-clamp-2 transition',
+          'text-xl font-bold leading-tight line-clamp-2 transition sm:text-[1.42rem]',
           variant === 'board' ? 'text-stone-100 group-hover:text-white' : 'text-neutral-900 group-hover:text-neutral-700',
         ]}
       >
         {post.data.title}
       </h3>
-      <p class:list={['text-sm leading-relaxed line-clamp-3', variant === 'board' ? 'text-slate-300' : 'text-neutral-600']}>
+      <p class:list={['text-sm leading-7 line-clamp-3', variant === 'board' ? 'text-slate-300' : 'text-neutral-600']}>
         {post.data.description}
       </p>
     </div>
-    <div class:list={['mt-auto pt-4', variant === 'board' ? 'border-t border-slate-700/80' : 'border-t border-neutral-100']}>
+    <div class:list={['mt-auto pt-5', variant === 'board' ? 'border-t border-slate-700/80' : 'border-t border-neutral-100']}>
       <PostCardMeta post={post} compact={false} showImpact={true} variant={variant} />
     </div>
   </div>

--- a/src/components/PostCardMeta.astro
+++ b/src/components/PostCardMeta.astro
@@ -19,19 +19,19 @@ const authorLabel = getAuthorProfile(post.data.author).displayName;
 const metaClass =
   variant === 'board'
     ? compact
-      ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.28em] text-slate-400'
-      : 'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-slate-400'
+      ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.3em] text-slate-400'
+      : 'flex flex-wrap items-center gap-2.5 text-[10px] font-semibold uppercase tracking-[0.34em] text-slate-400'
     : compact
-      ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
-      : 'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500';
+      ? 'flex flex-wrap items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.3em] text-neutral-500'
+      : 'flex flex-wrap items-center gap-2.5 text-[10px] font-semibold uppercase tracking-[0.34em] text-neutral-500';
 const impactClass =
   variant === 'board'
     ? compact
-      ? 'text-[9px] font-semibold uppercase tracking-[0.28em] text-slate-300'
-      : 'text-[10px] font-semibold uppercase tracking-[0.32em] text-slate-300'
+      ? 'text-[9px] font-semibold uppercase tracking-[0.3em] text-slate-300'
+      : 'text-[10px] font-semibold uppercase tracking-[0.34em] text-slate-300'
     : compact
-      ? 'text-[9px] font-semibold uppercase tracking-[0.28em] text-neutral-500'
-      : 'text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500';
+      ? 'text-[9px] font-semibold uppercase tracking-[0.3em] text-neutral-500'
+      : 'text-[10px] font-semibold uppercase tracking-[0.34em] text-neutral-500';
 const dividerClass = variant === 'board' ? 'h-1 w-1 rounded-full bg-slate-500/60' : 'h-1 w-1 rounded-full bg-neutral-300';
 ---
 

--- a/src/components/homepage/CommunityVote.astro
+++ b/src/components/homepage/CommunityVote.astro
@@ -7,26 +7,26 @@ const { prompt, options } = Astro.props as {
 };
 ---
 
-<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-vote" data-vote-widget>
-  <div class="space-y-1">
-    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-500">Community vote</p>
+<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)] sm:p-6" data-testid="pressure-room-vote" data-vote-widget>
+  <div class="space-y-1.5">
+    <p class="text-[10px] font-semibold uppercase tracking-[0.32em] text-stone-500">Community vote</p>
     <h3 class="text-xl font-black text-stone-950">{prompt}</h3>
-    <p class="text-sm leading-relaxed text-stone-600">
+    <p class="text-sm leading-7 text-stone-600">
       Local browser vote for now. This widget stores only your selection on this device until a sitewide API exists.
     </p>
   </div>
 
-  <div class="mt-5 grid gap-3">
+  <div class="mt-6 grid gap-3.5">
     {options.map((option) => (
       <button
         type="button"
-        class="vote-option flex items-start justify-between gap-4 rounded-[1.35rem] border border-stone-200 bg-white/70 px-4 py-3 text-left transition hover:border-stone-300 hover:bg-white"
+        class="vote-option flex items-start justify-between gap-4 rounded-[1.35rem] border border-stone-200 bg-white/70 px-4 py-[0.875rem] text-left transition hover:border-stone-300 hover:bg-white"
         data-vote-option
         data-option-id={option.id}
       >
-        <span class="space-y-1">
-          <span class="block text-sm font-semibold text-stone-950">{option.label}</span>
-          <span class="block text-sm leading-relaxed text-stone-600">{option.description}</span>
+        <span class="space-y-1.5">
+          <span class="block text-sm font-semibold leading-6 text-stone-950">{option.label}</span>
+          <span class="block text-sm leading-7 text-stone-600">{option.description}</span>
         </span>
         <span class="vote-pill mt-0.5 rounded-full border border-stone-300 bg-stone-100 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-600">
           Vote
@@ -35,7 +35,7 @@ const { prompt, options } = Astro.props as {
     ))}
   </div>
 
-  <p class="mt-4 text-sm font-semibold text-stone-700" data-vote-status>Choose one fear area to save your local vote.</p>
+  <p class="mt-5 text-sm font-semibold text-stone-700" data-vote-status>Choose one fear area to save your local vote.</p>
 </section>
 
 <script is:inline>

--- a/src/components/homepage/ImpactScoreFeed.astro
+++ b/src/components/homepage/ImpactScoreFeed.astro
@@ -8,10 +8,10 @@ const { items } = Astro.props as { items: PostEntry[] };
 const categoryByKey = new Map(TOPIC_CATEGORIES.map((category) => [category.key, category]));
 ---
 
-<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-impact-feed">
+<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)] sm:p-6" data-testid="pressure-room-impact-feed">
   <div class="flex items-end justify-between gap-4">
-    <div class="space-y-1">
-      <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-500">Latest impact score items</p>
+    <div class="space-y-1.5">
+      <p class="text-[10px] font-semibold uppercase tracking-[0.32em] text-stone-500">Latest impact score items</p>
       <h3 class="text-xl font-black text-stone-950">Route into the newest reporting</h3>
     </div>
     <a href="/posts" class="text-sm font-semibold text-stone-700 underline decoration-stone-300 underline-offset-4 transition hover:text-stone-950">
@@ -19,30 +19,30 @@ const categoryByKey = new Map(TOPIC_CATEGORIES.map((category) => [category.key, 
     </a>
   </div>
 
-  <div class="mt-5 space-y-3">
+  <div class="mt-6 space-y-3.5">
     {items.map((post) => {
       const category = post.data.topics?.[0] ? categoryByKey.get(post.data.topics[0]) : undefined;
 
       return (
         <a
           href={`/posts/${post.slug}/`}
-          class="flex flex-col gap-4 rounded-[1.35rem] border border-stone-200 bg-white/70 p-4 transition hover:border-stone-300 hover:bg-white sm:flex-row sm:items-center sm:justify-between"
+          class="flex flex-col gap-4 rounded-[1.35rem] border border-stone-200 bg-white/70 p-4 transition hover:border-stone-300 hover:bg-white sm:flex-row sm:items-center sm:justify-between sm:p-[1.125rem]"
           data-testid="pressure-room-impact-item"
         >
-          <div class="space-y-2">
-            <div class="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
+          <div class="space-y-2.5">
+            <div class="flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.24em] text-stone-500">
               <span>{category?.label ?? post.data.category ?? 'Key topic'}</span>
               <span aria-hidden class="h-1 w-1 rounded-full bg-stone-300" />
               <span>{formatDate(post.data.date)}</span>
             </div>
-            <h4 class="text-base font-bold leading-tight text-stone-950">{post.data.title}</h4>
-            <p class="text-sm leading-relaxed text-stone-600">{post.data.description}</p>
+            <h4 class="text-lg font-bold leading-tight text-stone-950">{post.data.title}</h4>
+            <p class="text-sm leading-7 text-stone-600">{post.data.description}</p>
           </div>
-          <div class="flex flex-none items-center gap-3 sm:flex-col sm:items-end">
+          <div class="flex flex-none items-center gap-3 sm:flex-col sm:items-end sm:gap-2.5">
             <span class="rounded-full border border-stone-300 bg-stone-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-stone-700">
               Impact {post.data.impact_score}
             </span>
-            <span class="text-sm font-semibold text-stone-700">Read post</span>
+            <span class="text-sm font-semibold tracking-[0.01em] text-stone-700">Read post</span>
           </div>
         </a>
       );

--- a/src/components/homepage/LeadDispatchCard.astro
+++ b/src/components/homepage/LeadDispatchCard.astro
@@ -25,13 +25,13 @@ const author = post ? getAuthorProfile(post.data.author) : undefined;
           <div class="absolute inset-0 bg-gradient-to-t from-black via-black/35 to-transparent"></div>
         </div>
       </a>
-      <div class="space-y-4 p-5">
-        <div class="space-y-2">
-          <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Lead dispatch</p>
+      <div class="space-y-5 p-5 sm:p-6">
+        <div class="space-y-2.5">
+          <p class="text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-400">Lead dispatch</p>
           <h3 class="text-2xl font-black tracking-tight text-white">{post.data.title}</h3>
-          <p class="text-sm leading-relaxed text-neutral-300">{post.data.description}</p>
+          <p class="text-sm leading-7 text-neutral-300">{post.data.description}</p>
         </div>
-        <div class="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-500">
+        <div class="flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.24em] text-neutral-500">
           <span>{formatDate(post.data.date)}</span>
           <span aria-hidden class="h-1 w-1 rounded-full bg-neutral-700" />
           <span>{`By ${author?.displayName}`}</span>
@@ -40,7 +40,7 @@ const author = post ? getAuthorProfile(post.data.author) : undefined;
             Impact Score {post.data.impact_score}
           </a>
         </div>
-        <div class="flex flex-wrap gap-3 pt-1">
+        <div class="flex flex-wrap gap-3.5 pt-1">
           <a
             href={`/posts/${post.slug}/`}
             class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200"
@@ -58,9 +58,9 @@ const author = post ? getAuthorProfile(post.data.author) : undefined;
     </>
   ) : (
     <div class="space-y-3 p-5">
-      <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Lead dispatch</p>
+      <p class="text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-400">Lead dispatch</p>
       <h3 class="text-2xl font-black text-white">No lead dispatch yet</h3>
-      <p class="text-sm leading-relaxed text-neutral-400">Publish the next post to populate the board's lead story slot.</p>
+      <p class="text-sm leading-7 text-neutral-400">Publish the next post to populate the board's lead story slot.</p>
     </div>
   )}
 </section>

--- a/src/components/homepage/LiveInputModules.astro
+++ b/src/components/homepage/LiveInputModules.astro
@@ -16,10 +16,10 @@ const toneDotClasses: Record<HomepageLiveModule['tone'], string> = {
 };
 ---
 
-<section class="space-y-4" data-testid="pressure-room-live-modules">
+<section class="space-y-5" data-testid="pressure-room-live-modules">
   <div class="flex items-end justify-between gap-4">
-    <div class="space-y-1">
-      <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Near-live inputs</p>
+    <div class="space-y-1.5">
+      <p class="text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-400">Near-live inputs</p>
       <h3 class="text-xl font-black text-white sm:text-2xl">What is moving right now</h3>
     </div>
     <p class="max-w-sm text-right text-xs leading-relaxed text-neutral-500">Pulled from recent STA publishing activity.</p>
@@ -27,13 +27,13 @@ const toneDotClasses: Record<HomepageLiveModule['tone'], string> = {
 
   <div class="grid gap-4 md:grid-cols-2 2xl:grid-cols-4">
     {modules.map((module) => (
-      <article class={`rounded-[1.6rem] border p-5 shadow-[0_18px_50px_-34px_rgba(0,0,0,0.75)] ${toneClasses[module.tone]}`}>
-        <div class="space-y-3">
+      <article class={`rounded-[1.6rem] border p-5 shadow-[0_18px_50px_-34px_rgba(0,0,0,0.75)] ${toneClasses[module.tone]} sm:p-[1.375rem]`}>
+        <div class="space-y-3.5">
           <div class="flex items-start justify-between gap-4">
-            <div class="space-y-2">
-              <div class="flex items-center gap-2">
+            <div class="space-y-2.5">
+              <div class="flex items-center gap-2.5">
                 <span class={`inline-block h-2 w-2 rounded-full ${toneDotClasses[module.tone]}`} aria-hidden="true"></span>
-                <p class="max-w-[15rem] text-[11px] font-semibold uppercase tracking-[0.24em] text-stone-500">{module.title}</p>
+                <p class="max-w-[15rem] text-[10px] font-semibold uppercase tracking-[0.26em] text-stone-500">{module.title}</p>
               </div>
               <p class="text-3xl font-black tracking-tight text-stone-950">{module.value}</p>
             </div>
@@ -41,9 +41,9 @@ const toneDotClasses: Record<HomepageLiveModule['tone'], string> = {
               {module.value}
             </span>
           </div>
-          <div class="space-y-2">
+          <div class="space-y-2.5">
             <p class="text-sm font-semibold uppercase tracking-[0.18em] text-stone-900">{module.summary}</p>
-            <p class="text-sm leading-relaxed text-stone-600">{module.detail}</p>
+            <p class="text-sm leading-7 text-stone-600">{module.detail}</p>
           </div>
           {module.items && module.items.length > 0 && (
             <ul class="flex flex-wrap gap-2">
@@ -53,8 +53,8 @@ const toneDotClasses: Record<HomepageLiveModule['tone'], string> = {
             </ul>
           )}
         </div>
-        <div class="mt-4 flex items-center justify-between gap-4 border-t border-stone-200 pt-4">
-          <p class="max-w-xs text-[11px] font-medium uppercase tracking-[0.18em] text-stone-500">{module.sourceLabel}</p>
+        <div class="mt-5 flex items-center justify-between gap-4 border-t border-stone-200 pt-4">
+          <p class="max-w-xs text-[10px] font-medium uppercase tracking-[0.22em] text-stone-500">{module.sourceLabel}</p>
           {module.href && module.hrefLabel && (
             <a href={module.href} class="text-sm font-semibold text-stone-700 underline decoration-stone-300 underline-offset-4 transition hover:text-stone-950">
               {module.hrefLabel}

--- a/src/components/homepage/MacroGauges.astro
+++ b/src/components/homepage/MacroGauges.astro
@@ -4,19 +4,19 @@ import type { HomepageMacroGauge } from '../../data/homepageBoard';
 const { gauges } = Astro.props as { gauges: HomepageMacroGauge[] };
 ---
 
-<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-macro-gauges">
-  <div class="space-y-1">
-    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-500">Editorial macro gauges</p>
+<section class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_20px_54px_-34px_rgba(0,0,0,0.78)] sm:p-6" data-testid="pressure-room-macro-gauges">
+  <div class="space-y-1.5">
+    <p class="text-[10px] font-semibold uppercase tracking-[0.32em] text-stone-500">Editorial macro gauges</p>
     <h3 class="text-xl font-black text-stone-950">How the bigger picture looks from here</h3>
   </div>
 
-  <div class="mt-5 space-y-5">
+  <div class="mt-6 space-y-6">
     {gauges.map((gauge) => (
-      <article class="space-y-2">
+      <article class="space-y-3">
         <div class="flex items-end justify-between gap-4">
-          <div class="space-y-1">
+          <div class="space-y-1.5">
             <h4 class="text-base font-bold text-stone-950">{gauge.title}</h4>
-            <p class="text-sm leading-relaxed text-stone-600">{gauge.summary}</p>
+            <p class="text-sm leading-7 text-stone-600">{gauge.summary}</p>
           </div>
           <span class="rounded-full border border-stone-300 bg-white/80 px-3 py-1 text-2xl font-black tracking-tight text-stone-950">
             {gauge.value}
@@ -26,7 +26,7 @@ const { gauges } = Astro.props as { gauges: HomepageMacroGauge[] };
           <div class="h-2 rounded-full bg-gradient-to-r from-stone-400 via-stone-200 to-neutral-50" style={`width:${gauge.value}%`}></div>
         </div>
         <div class="flex items-start justify-between gap-4">
-          <p class="max-w-sm text-sm leading-relaxed text-stone-500">{gauge.detail}</p>
+          <p class="max-w-sm text-sm leading-7 text-stone-500">{gauge.detail}</p>
           <a href={gauge.href} class="text-sm font-semibold text-stone-700 underline decoration-stone-300 underline-offset-4 transition hover:text-stone-950">
             {gauge.hrefLabel}
           </a>

--- a/src/components/homepage/PressureRoom.astro
+++ b/src/components/homepage/PressureRoom.astro
@@ -12,33 +12,35 @@ const { board } = Astro.props as { board: HomepageBoardModel };
 
 <section
   id="pressure-room"
-  class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(120,113,108,0.16),transparent_28%),radial-gradient(circle_at_top_right,rgba(120,113,108,0.08),transparent_26%),linear-gradient(180deg,rgba(16,16,18,0.98),rgba(5,5,6,1))] px-5 py-6 text-white shadow-[0_40px_120px_-48px_rgba(0,0,0,0.85)] sm:px-6 sm:py-7 lg:px-8 lg:py-8"
+  class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(120,113,108,0.16),transparent_28%),radial-gradient(circle_at_top_right,rgba(120,113,108,0.08),transparent_26%),linear-gradient(180deg,rgba(16,16,18,0.98),rgba(5,5,6,1))] px-5 py-6 text-white shadow-[0_40px_120px_-48px_rgba(0,0,0,0.85)] sm:px-6 sm:py-8 lg:px-8 lg:py-10"
   data-testid="pressure-room-section"
 >
   <div class="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:24px_24px] opacity-25" aria-hidden="true"></div>
 
-  <div class="relative flex flex-col gap-4 border-b border-white/10 pb-6 lg:flex-row lg:items-end lg:justify-between">
-    <div class="max-w-3xl space-y-3">
+  <div class="relative flex flex-col gap-5 border-b border-white/10 pb-7 lg:flex-row lg:items-end lg:justify-between">
+    <div class="max-w-3xl space-y-3.5">
       <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">LIVE INPUTS PEOPLE CAN ACTUALLY TRUST</p>
       <h2 class="text-3xl font-black tracking-tight text-white sm:text-[2.55rem]">Track the signals, map the fear areas, and see what is changing fastest.</h2>
-      <p class="text-base leading-relaxed text-neutral-300">
+      <p class="max-w-[46rem] text-base leading-8 text-neutral-300">
         Near-live signals show where coverage is clustering. Fear-area scores and macro gauges help you sort signal from noise before you
         decide what to read next.
       </p>
     </div>
-    <div class="grid max-w-xl gap-3 sm:grid-cols-2">
-      <div class="rounded-2xl border border-stone-200/80 bg-stone-50/95 px-4 py-3 text-sm leading-relaxed text-stone-600 shadow-[0_18px_40px_-34px_rgba(0,0,0,0.6)]">
-        <p class="font-semibold text-stone-950">Updated through {board.anchorDateLabel}</p>
-        <p class="mt-1">Recent STA coverage sets the pace for what shows up here first.</p>
+    <div class="grid max-w-xl gap-3.5 sm:grid-cols-2">
+      <div class="rounded-2xl border border-stone-200/80 bg-stone-50/95 px-4 py-[0.875rem] text-sm leading-7 text-stone-600 shadow-[0_18px_40px_-34px_rgba(0,0,0,0.6)]">
+        <p class="text-[10px] font-semibold uppercase tracking-[0.28em] text-stone-500">Coverage window</p>
+        <p class="mt-2 font-semibold text-stone-950">Updated through {board.anchorDateLabel}</p>
+        <p class="mt-1.5">Recent STA coverage sets the pace for what shows up here first.</p>
       </div>
-      <div class="rounded-2xl border border-stone-200/80 bg-stone-50/95 px-4 py-3 text-sm leading-relaxed text-stone-600 shadow-[0_18px_40px_-34px_rgba(0,0,0,0.6)]">
-        <p class="font-semibold text-stone-950">Read it cleanly</p>
-        <p class="mt-1">Near-live signals track recent coverage. Scores and gauges are editorial judgment.</p>
+      <div class="rounded-2xl border border-stone-200/80 bg-stone-50/95 px-4 py-[0.875rem] text-sm leading-7 text-stone-600 shadow-[0_18px_40px_-34px_rgba(0,0,0,0.6)]">
+        <p class="text-[10px] font-semibold uppercase tracking-[0.28em] text-stone-500">Reading mode</p>
+        <p class="mt-2 font-semibold text-stone-950">Read it cleanly</p>
+        <p class="mt-1.5">Near-live signals track recent coverage. Scores and gauges are editorial judgment.</p>
       </div>
     </div>
   </div>
 
-  <div class="relative mt-6 space-y-6">
+  <div class="relative mt-7 space-y-7">
     <LiveInputModules modules={board.liveModules} />
     <ThreatCardsBoard cards={board.threatCards} />
 

--- a/src/components/homepage/ThreatCardsBoard.astro
+++ b/src/components/homepage/ThreatCardsBoard.astro
@@ -4,22 +4,22 @@ import type { HomepageThreatCard } from '../../data/homepageBoard';
 const { cards } = Astro.props as { cards: HomepageThreatCard[] };
 ---
 
-<section class="space-y-4" data-testid="pressure-room-threat-cards">
-  <div class="space-y-1">
-    <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">Editorial threat board</p>
+<section class="space-y-5" data-testid="pressure-room-threat-cards">
+  <div class="space-y-1.5">
+    <p class="text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-400">Editorial threat board</p>
     <h3 class="text-xl font-black text-white sm:text-2xl">Fear-area scores and weekly deltas</h3>
   </div>
 
   <div class="grid gap-4 lg:grid-cols-2">
     {cards.map((card) => (
-      <article class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_22px_52px_-34px_rgba(0,0,0,0.78)]" data-testid="pressure-room-threat-card">
+      <article class="rounded-[1.75rem] border border-stone-200/80 bg-[linear-gradient(180deg,rgba(250,250,249,0.98),rgba(245,245,244,0.94))] p-5 shadow-[0_22px_52px_-34px_rgba(0,0,0,0.78)] sm:p-6" data-testid="pressure-room-threat-card">
         <div class="flex items-start justify-between gap-4">
-          <div class="space-y-2">
+          <div class="space-y-2.5">
             <div class="flex items-center gap-3">
               <span class="inline-block h-2.5 w-2.5 rounded-full" style={`background:${card.hub.color}`} aria-hidden="true" />
-              <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-stone-500">Editorial score</p>
+              <p class="text-[10px] font-semibold uppercase tracking-[0.3em] text-stone-500">Editorial score</p>
             </div>
-            <h4 class="text-lg font-black text-stone-950">{card.hub.shortName}</h4>
+            <h4 class="text-xl font-black leading-tight text-stone-950">{card.hub.shortName}</h4>
           </div>
           <div class="text-right">
             <p class="text-4xl font-black tracking-tight text-stone-950">{card.score}</p>
@@ -34,12 +34,12 @@ const { cards } = Astro.props as { cards: HomepageThreatCard[] };
           <div class="h-2 rounded-full" style={`width:${card.score}%;background:${card.hub.color};`}></div>
         </div>
 
-        <div class="mt-4 space-y-2">
-          <p class="text-sm font-semibold leading-relaxed text-stone-900">{card.stance}</p>
-          <p class="text-sm leading-relaxed text-stone-600">{card.summary}</p>
+        <div class="mt-5 space-y-2.5">
+          <p class="text-sm font-semibold leading-7 text-stone-900">{card.stance}</p>
+          <p class="text-sm leading-7 text-stone-600">{card.summary}</p>
         </div>
 
-        <div class="mt-5 flex flex-wrap items-center gap-3 border-t border-stone-200 pt-4">
+        <div class="mt-6 flex flex-wrap items-center gap-[0.875rem] border-t border-stone-200 pt-[1.125rem]">
           <a
             href={`${card.hub.slug}/`}
             class="inline-flex items-center justify-center rounded-full border border-stone-300 bg-white/70 px-4 py-2 text-sm font-semibold text-stone-950 transition hover:border-stone-400 hover:bg-white"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,30 +32,30 @@ const heroCards = [
 ---
 
 <Layout title="Survive the AI - Prepare, adapt, and stay ahead">
-  <main class="bg-[radial-gradient(circle_at_top,rgba(120,113,108,0.15),transparent_28%),radial-gradient(circle_at_20%_0%,rgba(255,255,255,0.06),transparent_20%),linear-gradient(180deg,#09090b_0%,#111113_34%,#0b0b0d_100%)] py-10 text-neutral-100 sm:py-14">
-    <div class="mx-auto max-w-screen-xl space-y-10 px-4 sm:px-6 lg:px-8">
-      <section class="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(20,20,23,0.96),rgba(11,11,13,0.99))] px-5 py-6 shadow-[0_32px_90px_-52px_rgba(0,0,0,0.82)] sm:px-6 sm:py-7 lg:px-8 lg:py-8" data-testid="homepage-hero">
-        <div class="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_360px]">
-          <div class="space-y-6">
-            <div class="space-y-4">
+  <main class="bg-[radial-gradient(circle_at_top,rgba(120,113,108,0.15),transparent_28%),radial-gradient(circle_at_20%_0%,rgba(255,255,255,0.06),transparent_20%),linear-gradient(180deg,#09090b_0%,#111113_34%,#0b0b0d_100%)] py-10 text-neutral-100 sm:py-14 lg:py-16">
+    <div class="mx-auto max-w-screen-xl space-y-12 px-4 sm:px-6 lg:px-8 lg:space-y-14">
+      <section class="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(20,20,23,0.96),rgba(11,11,13,0.99))] px-5 py-6 shadow-[0_32px_90px_-52px_rgba(0,0,0,0.82)] sm:px-6 sm:py-8 lg:px-8 lg:py-10" data-testid="homepage-hero">
+        <div class="grid gap-8 xl:grid-cols-[minmax(0,1.08fr)_360px] xl:gap-10">
+          <div class="space-y-8">
+            <div class="space-y-5">
               <div class="flex flex-wrap items-center gap-3">
                 <span class="inline-flex items-center gap-2 rounded-full border border-[#ff6b57]/25 bg-[#ff6b57]/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] text-[#ff8b79]">
                   <span class="h-1.5 w-1.5 rounded-full bg-[#ff6b57]" aria-hidden="true"></span>
                   LIVE AI FEAR SIGNALS
                 </span>
               </div>
-              <div class="max-w-4xl space-y-4">
+              <div class="max-w-4xl space-y-5">
                 <h1 class="max-w-3xl text-4xl font-black leading-[0.98] tracking-tight text-white sm:text-[3.6rem]">
                   The AI flood is here. Learn to swim.
                 </h1>
-                <p class="max-w-3xl text-base leading-relaxed text-neutral-300 sm:text-lg">
+                <p class="max-w-3xl text-base leading-8 text-neutral-300 sm:text-[1.05rem]">
                   SurviveTheAI tracks where pressure is rising across work, school, trust, fraud, relationships, and cognitive life using
                   a mix of live inputs people can trust and hard-won editorial judgment.
                 </p>
               </div>
             </div>
 
-            <div class="flex flex-wrap gap-3">
+            <div class="flex flex-wrap gap-3.5">
               <a
                 href="#pressure-room"
                 class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/35"
@@ -72,37 +72,37 @@ const heroCards = [
               </a>
             </div>
 
-            <div class="grid gap-3 md:grid-cols-3">
+            <div class="grid gap-3.5 md:grid-cols-3">
               {heroCards.map((card) => (
-                <article class="rounded-[1.4rem] border border-white/10 bg-white/[0.045] p-4 shadow-[0_18px_40px_-32px_rgba(0,0,0,0.78)]">
-                  <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-neutral-500">{card.title}</p>
-                  <p class="mt-3 text-sm leading-relaxed text-neutral-300">{card.copy}</p>
+                <article class="rounded-[1.4rem] border border-white/10 bg-white/[0.045] p-4 shadow-[0_18px_40px_-32px_rgba(0,0,0,0.78)] sm:p-5">
+                  <p class="text-[10px] font-semibold uppercase tracking-[0.28em] text-neutral-500">{card.title}</p>
+                  <p class="mt-3.5 text-sm leading-7 text-neutral-300">{card.copy}</p>
                 </article>
               ))}
             </div>
           </div>
 
-          <aside class="rounded-[1.7rem] border border-white/10 bg-black/25 p-4 shadow-[0_24px_54px_-36px_rgba(0,0,0,0.85)]" data-testid="most-watched-panel">
+          <aside class="rounded-[1.7rem] border border-white/10 bg-black/25 p-4 shadow-[0_24px_54px_-36px_rgba(0,0,0,0.85)] sm:p-5" data-testid="most-watched-panel">
             <div class="flex items-center justify-between gap-3 border-b border-white/10 pb-3">
               <div>
-                <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-500">Most watched this week</p>
+                <p class="text-[10px] font-semibold uppercase tracking-[0.32em] text-neutral-500">Most watched this week</p>
                 <p class="mt-1 text-sm text-neutral-400">Stories readers keep circling back to.</p>
               </div>
             </div>
 
-            <div class="mt-4 space-y-3">
+            <div class="mt-5 space-y-3.5">
               {mostWatched.map((post) => (
                 <a
                   href={`/posts/${post.slug}/`}
-                  class="block rounded-[1.3rem] border border-white/10 bg-white/[0.04] p-4 transition hover:border-white/20 hover:bg-white/[0.06]"
+                  class="block rounded-[1.3rem] border border-white/10 bg-white/[0.04] p-4 transition hover:border-white/20 hover:bg-white/[0.06] sm:p-[1.125rem]"
                 >
-                  <div class="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.24em] text-neutral-500">
+                  <div class="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.26em] text-neutral-500">
                     <span>Fear paper</span>
                     <span aria-hidden class="h-1 w-1 rounded-full bg-white/15"></span>
                     <span>{formatDate(post.data.date)}</span>
                   </div>
-                  <h2 class="mt-3 text-lg font-black leading-tight text-white">{post.data.title}</h2>
-                  <p class="mt-2 text-sm leading-relaxed text-neutral-400">{post.data.description}</p>
+                  <h2 class="mt-3.5 text-lg font-black leading-tight text-white">{post.data.title}</h2>
+                  <p class="mt-2.5 text-sm leading-7 text-neutral-400">{post.data.description}</p>
                 </a>
               ))}
             </div>
@@ -112,22 +112,22 @@ const heroCards = [
 
       <PressureRoom board={board} />
 
-      <div class="space-y-8">
+      <div class="space-y-9 lg:space-y-10">
         {editorPicks.length > 0 && (
           <section
-            class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(148,163,184,0.12),transparent_30%),linear-gradient(180deg,rgba(24,28,35,0.94),rgba(15,18,24,0.98))] px-5 py-6 shadow-[0_28px_80px_-50px_rgba(0,0,0,0.72)] sm:px-6 sm:py-7 lg:px-8 lg:py-8"
+            class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(148,163,184,0.12),transparent_30%),linear-gradient(180deg,rgba(24,28,35,0.94),rgba(15,18,24,0.98))] px-5 py-6 shadow-[0_28px_80px_-50px_rgba(0,0,0,0.72)] sm:px-6 sm:py-8 lg:px-8 lg:py-9"
             data-testid="start-here-section"
           >
-            <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-              <div class="max-w-3xl space-y-1">
+            <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+              <div class="max-w-3xl space-y-2">
                 <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Start Here / Editor's Picks</p>
                 <h2 class="text-2xl font-black text-white sm:text-3xl">Use the board, then take the guided path</h2>
-                <p class="text-neutral-300">
+                <p class="max-w-[44rem] text-[15px] leading-7 text-neutral-300 sm:text-base">
                   New readers should start with the pressure map, then use Start Here and these editor picks to understand the stakes,
                   the patterns, and the practical next questions.
                 </p>
               </div>
-              <div class="flex flex-wrap gap-3">
+              <div class="flex flex-wrap gap-3.5">
                 <a
                   href="/start-here"
                   class="inline-flex items-center justify-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/35"
@@ -146,7 +146,7 @@ const heroCards = [
                 </a>
               </div>
             </div>
-            <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div class="grid grid-cols-1 gap-6 pt-1 lg:grid-cols-3">
               {editorPicks.map((post) => (
                 <PostCard post={post} variant="board" />
               ))}
@@ -173,7 +173,7 @@ const heroCards = [
         </div>
 
         <section
-          class="rounded-[1.9rem] border border-stone-400/15 bg-[linear-gradient(180deg,rgba(41,37,36,0.58),rgba(23,23,25,0.74))] px-5 py-6 shadow-[0_26px_76px_-56px_rgba(0,0,0,0.58)] sm:px-6 sm:py-7 lg:px-8 lg:py-8"
+          class="rounded-[1.9rem] border border-stone-400/15 bg-[linear-gradient(180deg,rgba(41,37,36,0.58),rgba(23,23,25,0.74))] px-5 py-6 shadow-[0_26px_76px_-56px_rgba(0,0,0,0.58)] sm:px-6 sm:py-8 lg:px-8 lg:py-9"
           data-testid="homepage-subscribe"
         >
           <SubscribeInline
@@ -186,33 +186,33 @@ const heroCards = [
         </section>
 
         <section
-          class="rounded-[2rem] border border-stone-300/15 bg-[radial-gradient(circle_at_top_right,rgba(120,113,108,0.12),transparent_28%),linear-gradient(180deg,rgba(30,33,39,0.88),rgba(20,23,28,0.94))] px-5 py-6 shadow-[0_28px_82px_-56px_rgba(0,0,0,0.62)] sm:px-6 sm:py-7 lg:px-8 lg:py-8"
+          class="rounded-[2rem] border border-stone-300/15 bg-[radial-gradient(circle_at_top_right,rgba(120,113,108,0.12),transparent_28%),linear-gradient(180deg,rgba(30,33,39,0.88),rgba(20,23,28,0.94))] px-5 py-6 shadow-[0_28px_82px_-56px_rgba(0,0,0,0.62)] sm:px-6 sm:py-8 lg:px-8 lg:py-9"
           data-testid="survival-areas-section"
         >
-          <div class="space-y-1">
+          <div class="space-y-2">
             <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Fear Areas</p>
             <h2 class="text-2xl font-black text-white sm:text-3xl">Route by fear area</h2>
-            <p class="max-w-3xl text-neutral-300">
+            <p class="max-w-3xl text-[15px] leading-7 text-neutral-300 sm:text-base">
               The board condenses the pressure. The fear-area hubs hold the ongoing reporting, practical framing, and deeper archive for
               each zone.
             </p>
           </div>
-          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
+          <div class="grid grid-cols-1 gap-4 pt-2 sm:grid-cols-2 xl:grid-cols-5">
             {board.threatCards.map((card) => (
               <a
                 href={`${card.hub.slug}/`}
-                class="group flex h-full flex-col justify-between gap-4 rounded-[1.6rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_18px_44px_-34px_rgba(0,0,0,0.75)] transition hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/25"
+                class="group flex h-full flex-col justify-between gap-5 rounded-[1.6rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_18px_44px_-34px_rgba(0,0,0,0.75)] transition hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/25 sm:p-[1.375rem]"
                 data-testid="survival-area-tile"
               >
-                <div class="space-y-3">
+                <div class="space-y-3.5">
                   <div class="flex items-center gap-3">
                     <span class="inline-block h-2.5 w-2.5 rounded-full" style={`background:${card.hub.color}`} aria-hidden="true" />
-                    <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-neutral-500">Fear area</p>
+                    <p class="text-[10px] font-semibold uppercase tracking-[0.3em] text-neutral-500">Fear area</p>
                   </div>
                   <h3 class="text-lg font-black leading-tight text-white transition group-hover:text-neutral-200">{card.hub.shortName}</h3>
-                  <p class="text-sm leading-relaxed text-neutral-300">{card.hub.tagline}</p>
+                  <p class="text-sm leading-7 text-neutral-300">{card.hub.tagline}</p>
                 </div>
-                <span class="text-sm font-semibold text-white">Open the hub</span>
+                <span class="text-sm font-semibold tracking-[0.01em] text-white">Open the hub</span>
               </a>
             ))}
           </div>
@@ -224,18 +224,18 @@ const heroCards = [
 
         {remaining.length > 0 && (
           <section
-            class="rounded-[2rem] border border-stone-300/15 bg-[radial-gradient(circle_at_top_left,rgba(120,113,108,0.12),transparent_28%),linear-gradient(180deg,rgba(34,31,32,0.84),rgba(20,20,23,0.92))] px-5 py-6 shadow-[0_28px_82px_-56px_rgba(0,0,0,0.62)] sm:px-6 sm:py-7 lg:px-8 lg:py-8"
+            class="rounded-[2rem] border border-stone-300/15 bg-[radial-gradient(circle_at_top_left,rgba(120,113,108,0.12),transparent_28%),linear-gradient(180deg,rgba(34,31,32,0.84),rgba(20,20,23,0.92))] px-5 py-6 shadow-[0_28px_82px_-56px_rgba(0,0,0,0.62)] sm:px-6 sm:py-8 lg:px-8 lg:py-9"
             data-testid="library-cta-section"
           >
-            <div class="space-y-1">
+            <div class="space-y-2">
               <p class="text-xs font-semibold uppercase tracking-[0.32em] text-neutral-500">Library / Archive</p>
               <h2 class="text-2xl font-black text-white sm:text-3xl">Keep moving through the reporting</h2>
-              <p class="max-w-3xl text-neutral-300">
+              <p class="max-w-3xl text-[15px] leading-7 text-neutral-300 sm:text-base">
                 The latest board only shows the surface. The library is where the deeper reporting, archive work, and longer survival map
                 keep filling in.
               </p>
             </div>
-            <div class="flex flex-wrap gap-3">
+            <div class="flex flex-wrap gap-3.5 pt-1">
               <a
                 href="/posts"
                 class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/35"


### PR DESCRIPTION
## Summary
- refine spacing rhythm between major homepage sections and within each homepage block
- strengthen hierarchy between labels, headings, descriptions, metadata, and CTA rows
- give editorial cards more breathing room and make Pressure Room widgets scan more cleanly without changing family logic or surface hierarchy

## Validation
- `npm run build`
- `npx playwright test tests/homepage.spec.ts`